### PR TITLE
mcc-kmod: use latest mcc kernel module from toradex git

### DIFF
--- a/recipes-kernel/kernel-module-mcc-toradex/kernel-module-mcc-toradex_1.06+toradex2.bb
+++ b/recipes-kernel/kernel-module-mcc-toradex/kernel-module-mcc-toradex_1.06+toradex2.bb
@@ -13,7 +13,7 @@ inherit module
 SRC_URI = "git://github.com/toradex/mcc-kmod.git;protocol=git;branch=${SRCBRANCH}"
 
 SRCBRANCH = "master"
-SRCREV = "d68c842ff871c7930c59366cf76b54c52a045a90"
+SRCREV = "083388fa5cce79c239988d61543322d91996aa8d"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Use the latest version of mcc-kmod which is adapted for
v4.4 kernel.