### PR TITLE
colibri-vf: use strong assignment of SERIAL_CONSOLE, fixes #5

### DIFF
--- a/conf/machine/colibri-vf.conf
+++ b/conf/machine/colibri-vf.conf
@@ -35,6 +35,6 @@ MKUBIFS_ARGS = " -c 8112 -e 124KiB -m 2KiB -F"
 UBINIZE_ARGS = " -p 128KiB -m 2048 -s 2048"
 UBI_VOLNAME = "rootfs"
 
-SERIAL_CONSOLE ?= "115200 ttyLP0"
+SERIAL_CONSOLE = "115200 ttyLP0"
 
 MACHINE_FEATURES += "usbgadget usbhost vfat alsa touchscreen"


### PR DESCRIPTION
SERIAL_CONSOLE would otherwise stay at the default setting as defined in imx-base.inc but this setting would make it try to spawn a getty on a non-existing device on the colibri-vf and login on the UART console would not work. Fixes #5 