### PR TITLE
u-boot-gateworks-imx: fix recipe building

### DIFF
--- a/recipes-bsp/u-boot/u-boot-gateworks-imx_2015.04.bb
+++ b/recipes-bsp/u-boot/u-boot-gateworks-imx_2015.04.bb
@@ -10,5 +10,7 @@ PV = "v2015.04+git${SRCPV}"
 SRCREV = "040377aefd06c8eef41763868fc9c6df2cbf9b1c"
 SRC_URI = "git://github.com/Gateworks/u-boot-imx6.git;branch=gateworks_v2015.04"
 
+S = ${WORKDIR}/git
+
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 COMPATIBLE_MACHINE = "(ventana)"


### PR DESCRIPTION
Add the git repository in the recipe in order to build u-boot for
Gateworks imx6 boards.

Signed-off-by: Sandra Tobajas <sandra.tobajas@savoirfairelinux.com>