### PR TITLE
u-boot-gateworks-imx: Fix parsing errors

### DIFF
--- a/recipes-bsp/u-boot/u-boot-gateworks-imx_2015.04.bb
+++ b/recipes-bsp/u-boot/u-boot-gateworks-imx_2015.04.bb
@@ -10,7 +10,7 @@ PV = "v2015.04+git${SRCPV}"
 SRCREV = "040377aefd06c8eef41763868fc9c6df2cbf9b1c"
 SRC_URI = "git://github.com/Gateworks/u-boot-imx6.git;branch=gateworks_v2015.04"
 
-S = ${WORKDIR}/git
+S = "${WORKDIR}/git"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 COMPATIBLE_MACHINE = "(ventana)"


### PR DESCRIPTION
Bitbake assignments cannnot be non-quoted on RHS, fixes parsing errors

Parsing recipes...ERROR: ParseError at
/mnt/jenkins/workspace/yocto-world-glibc/sources/meta-freescale-3rdparty/recipes-bsp/u-boot/u-boot-gateworks-imx_2015.04.bb:13:
unparsed line: 'S = ${WORKDIR}/git'

Signed-off-by: Khem Raj <raj.khem@gmail.com>
Cc: Sandra Tobajas <sandra.tobajas@savoirfairelinux.com>