### PR TITLE
pr/ccimx6ul qca6564: Add wireless support for ConnectCore 6UL SOM and SBCs

### DIFF
--- a/conf/machine/include/ccimx6ulsom.inc
+++ b/conf/machine/include/ccimx6ulsom.inc
@@ -21,6 +21,14 @@ UBOOT_CONFIG[ccimx6ulstarter] = "ccimx6ulstarter_defconfig"
 MACHINE_EXTRA_RDEPENDS += " \
     mtd-utils-ubifs \
 "
+
+MACHINE_FEATURES += " wifi bluetooth"
+
+MACHINE_EXTRA_RRECOMMENDS += " \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'kernel-module-qca6564 linux-firmware-qca6564-wifi', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'bluetooth', 'linux-firmware-qca6564-bt', '', d)} \
+"
+
 # mkfs.ubifs parameters for boot partition (the one holding kernel and device tree files)
 # Max LEB count (-c 255) calculated for a partition of up to 32 MiB considering 128 KiB erase-block size.
 MKUBIFS_BOOT_ARGS ?= "-m 2048 -e 126976 -c 255"

--- a/recipes-core/init-ifupdown/init-ifupdown/ccimx6ulsbcexpress/interfaces
+++ b/recipes-core/init-ifupdown/init-ifupdown/ccimx6ulsbcexpress/interfaces
@@ -4,7 +4,29 @@
 auto lo
 iface lo inet loopback
 
-# Wired interfaces
+# Wireless interfaces
+
+# Client infrastructure mode
+auto wlan0
+iface wlan0 inet static
+	address 192.168.8.2
+	netmask 255.255.255.0
+	network 192.168.8.0
+	wireless_mode managed
+	wireless_essid any
+	wpa-driver nl80211
+	wpa-conf /etc/wpa_supplicant.conf
+
+# SoftAP mode
+auto wlan1
+iface wlan1 inet static
+	address 192.168.9.2
+	netmask 255.255.255.0
+	network 192.168.9.0
+	post-up /etc/init.d/hostapd start
+	pre-down /etc/init.d/hostapd stop
+
+# Wired  interfaces
 auto eth0
 iface eth0 inet dhcp
 

--- a/recipes-core/init-ifupdown/init-ifupdown/ccimx6ulsbcpro/interfaces
+++ b/recipes-core/init-ifupdown/init-ifupdown/ccimx6ulsbcpro/interfaces
@@ -4,6 +4,28 @@
 auto lo
 iface lo inet loopback
 
+# Wireless interfaces
+
+# Client infrastructure mode
+auto wlan0
+iface wlan0 inet static
+	address 192.168.8.2
+	netmask 255.255.255.0
+	network 192.168.8.0
+	wireless_mode managed
+	wireless_essid any
+	wpa-driver nl80211
+	wpa-conf /etc/wpa_supplicant.conf
+
+# SoftAP mode
+auto wlan1
+iface wlan1 inet static
+	address 192.168.9.2
+	netmask 255.255.255.0
+	network 192.168.9.0
+	post-up /etc/init.d/hostapd start
+	pre-down /etc/init.d/hostapd stop
+
 # Wired interfaces
 auto eth1
 iface eth0 inet dhcp

--- a/recipes-core/udev/udev-rules-digi.bb
+++ b/recipes-core/udev/udev-rules-digi.bb
@@ -1,0 +1,25 @@
+# Copyright (C) 2019 Digi International.
+
+DESCRIPTION = "udev rules for Digi International SOMs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI_ccimx6ul = " \
+	file://81-qcom-wifi.rules \
+	file://qca6564-init-wifi.sh \
+	file://81-qcom-bt.rules \
+	file://qca6564-attach.sh \
+"
+
+S = "${WORKDIR}"
+
+do_install_ccimx6ul () {
+	install -d ${D}${sysconfdir}/udev/rules.d
+	install -m 0644 ${WORKDIR}/81-qcom-wifi.rules ${D}${sysconfdir}/udev/rules.d/
+	install -m 0644 ${WORKDIR}/81-qcom-bt.rules ${D}${sysconfdir}/udev/rules.d/
+	install -d ${D}${sysconfdir}/udev/scripts/
+	install -m 0755 ${WORKDIR}/qca6564-init-wifi.sh ${D}${sysconfdir}/udev/scripts/
+	install -m 0755 ${WORKDIR}/qca6564-attach.sh ${D}${sysconfdir}/udev/scripts/
+}
+
+COMPATIBLE_MACHINE = "(ccimx6ul)"

--- a/recipes-core/udev/udev-rules-digi/ccimx6ul/81-qcom-bt.rules
+++ b/recipes-core/udev/udev-rules-digi/ccimx6ul/81-qcom-bt.rules
@@ -1,0 +1,2 @@
+# Attach QCA6564 Bluetooth (uart)
+SUBSYSTEM=="tty", KERNEL=="ttymxc0", ACTION=="add", RUN="/etc/udev/scripts/qca6564-attach.sh start"

--- a/recipes-core/udev/udev-rules-digi/ccimx6ul/81-qcom-wifi.rules
+++ b/recipes-core/udev/udev-rules-digi/ccimx6ul/81-qcom-wifi.rules
@@ -1,0 +1,2 @@
+# Load Qualcomm wireless module (sdio)
+SUBSYSTEM=="sdio", ACTION=="add", ENV{MODALIAS}=="sdio:c00v0271d050A", RUN="/etc/udev/scripts/qca6564-init-wifi.sh"

--- a/recipes-core/udev/udev-rules-digi/ccimx6ul/qca6564-attach.sh
+++ b/recipes-core/udev/udev-rules-digi/ccimx6ul/qca6564-attach.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+#===============================================================================
+#
+#  Copyright (C) 2019 by Digi International Inc.
+#  All rights reserved.
+#
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 2 as published by
+#  the Free Software Foundation.
+#
+#
+#  !Description: Initialize bluetooth hardware
+#
+#===============================================================================
+
+# Bluetooth power GPIO
+BT_EN_QCA_GPIO_NR="137"
+
+# set_gpio_value <gpio_nr> <value>
+set_gpio_value() {
+	local SG_GPIONR="${1}"
+	local SG_GPIOVAL="${2}"
+	local SG_GPIOPATH="/sys/class/gpio/gpio${SG_GPIONR}"
+
+	[ -d "${SG_GPIOPATH}" ] || printf "%s" "${SG_GPIONR}" > /sys/class/gpio/export
+	printf out > "${SG_GPIOPATH}/direction" && sleep .2
+	printf "${SG_GPIOVAL}" > "${SG_GPIOPATH}/value" && sleep .2
+	[ -d "${SG_GPIOPATH}" ] && printf "%s" "${SG_GPIONR}" > /sys/class/gpio/unexport
+}
+
+# powercycle_gpio <gpio_nr>
+powercycle_gpio() {
+	set_gpio_value "${1}" 0
+	set_gpio_value "${1}" 1
+}
+
+set_mac_address() {
+	# Get MAC address from the device tree. Use a default value if it has not been set.
+	BT_MACADDR="$(hexdump -ve '1/1 "%02X" ":"' /proc/device-tree/bluetooth/mac-address 2>/dev/null | sed 's/:$//g')"
+	if [ -z "${BT_MACADDR}" ] || [ "${BT_MACADDR}" = "00:00:00:00:00:00" ]; then
+		BT_MACADDR="00:04:F3:FF:FF:BB"
+	fi
+
+	# Convert the BT address to the hcitool command format.
+	#   Example:  "00:04:F3:11:22:33" coverted to "33 22 11 F3 04 00"
+	HCI_BT_ADDR="$(echo ${BT_MACADDR} | sed -e 's,^\(..\):\(..\):\(..\):\(..\):\(..\):\(..\)$,\6 \5 \4 \3 \2 \1,g')"
+
+	# Up the interface to be able to send hci commands
+	hciconfig hci0 up ||  echo "Cannot bring up bluetooth interface after initial attach" || exit 1
+
+	# Set the MAC address
+	hcitool -i hci0 cmd 3F 000B 01 02 06 ${HCI_BT_ADDR} > /dev/null || echo "Unable to set BT MAC Address" || exit 1
+
+	# Bring the interface down/up to apply the MAC change
+	hciconfig hci0 down ||  echo "Cannot bring down bluetooth interface after setting MAC" || exit 1
+	hciconfig hci0 up ||  echo "Cannot bring up bluetooth interface after setting MAC" || exit 1
+
+}
+
+bluetooth_init() {
+	# Start the Bluetooth driver and bring up the interface
+	killproc hciattach
+	powercycle_gpio "${BT_EN_QCA_GPIO_NR}"
+	hciattach ttymxc0 qualcomm 115200 -t3 flow unused > /dev/null 2>&1 || BT_ERROR="FAIL (hciattach)"
+	set_mac_address || BT_ERROR="Unable to set MAC address"
+}
+
+# Source function library
+. /etc/init.d/functions
+
+case "$1" in
+	start)
+		if [ -d "/proc/device-tree/bluetooth" ]; then
+			echo -n "Starting bluetooth hardware: "
+			bluetooth_init
+			echo "${BT_ERROR:-done.}"
+		fi
+		;;
+	stop)
+		if [ -d "/sys/class/bluetooth/hci0" ]; then
+			echo -n "Stopping bluetooth hardware: "
+			killproc hciattach
+			# Power down bluetooth
+			set_gpio_value "${BT_EN_QCA_GPIO_NR}" 0
+			echo "done."
+		fi
+		;;
+	restart)
+		$0 stop
+		sleep 1
+		$0 start
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart}"
+		exit 1
+		;;
+esac

--- a/recipes-core/udev/udev-rules-digi/ccimx6ul/qca6564-init-wifi.sh
+++ b/recipes-core/udev/udev-rules-digi/ccimx6ul/qca6564-init-wifi.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Digi International Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+# At this point of the boot (udev script), the system log (syslog) is not
+# available yet, so use the kernel log buffer from userspace.
+log() {
+	printf "<$1>qca6564: $2\n" >/dev/kmsg
+}
+
+# Do nothing if the module is already loaded
+grep -qws 'wlan' /proc/modules && exit 0
+
+FIRMWARE_DIR="/lib/firmware"
+MACFILE="${FIRMWARE_DIR}/wlan/wlan_mac.bin"
+TMP_MACFILE="$(mktemp -t wlan_mac.XXXXXX)"
+
+# Read the MACs from DeviceTree. We can have up to four wireless interfaces
+# The only required one is wlan0 that is mapped with device tree mac address
+# without suffix.
+for index in $(seq 0 3); do
+	MAC_ADDR="$(hexdump -ve '1/1 "%02X"' /proc/device-tree/wireless/mac-address${index%0} 2>/dev/null)"
+	if [ "${index}" = "0" ] && { [ -z "${MAC_ADDR}" ] || [ "${MAC_ADDR}" = "00:00:00:00:00:00" ]; }; then
+		# Set a default MAC for wlan0
+		MAC_ADDR="0004F3FFFFFB"
+	fi
+
+	# Add the MAC address to the firmware file with the expected format
+	echo "Intf${index}MacAddress=${MAC_ADDR}" >> ${TMP_MACFILE}
+done
+
+# Override the MAC firmware file only if the MAC file has changed.
+if ! cmp -s ${TMP_MACFILE} ${MACFILE}; then
+	cp ${TMP_MACFILE} ${MACFILE}
+fi
+rm -f "${TMP_MACFILE}"
+
+OTP_REGION_CODE="$(cat /proc/device-tree/digi,hwid,cert 2>/dev/null | tr -d '\0')"
+DTB_REGION_CODE="$(cat /proc/device-tree/wireless/regulatory-domain 2>/dev/null | tr -d '\0')"
+US_CODE="0x0"
+WW_CODE="0x1"
+JP_CODE="0x2"
+# Check if the DTB_REGION_CODE is in the list of valid codes,
+# if not use the OTP programmed value.
+case "${DTB_REGION_CODE}" in
+	${US_CODE} | ${WW_CODE} | ${JP_CODE})
+		REGULATORY_DOMAIN="${DTB_REGION_CODE}";;
+	*)
+		if [ -n "${DTB_REGION_CODE}" ]; then
+			log "5" "[WARN] Invalid region code in device tree, using OTP value"
+		fi
+		REGULATORY_DOMAIN="${OTP_REGION_CODE}";;
+esac
+
+
+# Create symbolic links to the proper FW files depending on the country region
+# Use a sub-shell here to change to firmware directory
+(
+	cd "${FIRMWARE_DIR}"
+
+	BDATA_SOURCE="bdwlan30_US.bin"
+	case "${REGULATORY_DOMAIN}" in
+		${US_CODE})
+			log "5" "Setting US wireless region";;
+		${WW_CODE}|${JP_CODE})
+			if [ -f "bdwlan30_World.bin" ]; then
+				log "5" "Setting WW (world wide) wireless region"
+				BDATA_SOURCE="bdwlan30_World.bin"
+			else
+				log "5" "[WARN] No WW (worldwide) board data file, using US"
+			fi
+			;;
+		"")
+			log "5" "[WARN] region code not found, using US";;
+		*)
+			log "5" "[WARN] Invalid region code, using US";;
+	esac
+
+	# We don't want to rewrite NAND every time we boot so only
+	# change the links if they are wrong.
+	BDATA_LINK="bdwlan30.bin"
+	UTFBDATA_LINK="utfbd30.bin"
+	if [ ! -e "${BDATA_LINK}" ] || ! cmp -s "${BDATA_LINK}" "${BDATA_SOURCE}"; then
+		ln -sf "${BDATA_SOURCE}" "${BDATA_LINK}"
+		ln -sf "${BDATA_SOURCE}" "${UTFBDATA_LINK}"
+	fi
+)
+
+# Load the wireless module with the params defined in modprobe.d/qca6564.conf
+# and reduce the console log level to avoid debug messages at boot time
+LOGLEVEL="$(sed -ne 's,^kernel.printk[^=]*=[[:blank:]]*\(.*\)$,\1,g;T;p' /etc/sysctl.conf 2>/dev/null)"
+[ -n "${LOGLEVEL}" ] && sysctl -q -w kernel.printk="${LOGLEVEL}"
+modprobe wlan
+
+# Verify the interface is present
+if [ -d "/sys/class/net/wlan0" ]; then
+	# Create 'wlan1' virtual interface
+	if [ -s "/proc/device-tree/wireless/mac-address1" ] &&
+	   [ -s "/proc/device-tree/wireless/mac-address2" ] &&
+	   [ -s "/proc/device-tree/wireless/mac-address3" ]; then
+	   :
+	else
+		echo "[WARN] Using default MAC addresses for virtual interfaces."
+	fi
+	iw dev wlan0 interface add wlan1 type __ap
+else
+	log "3" "[ERROR] Loading qca6564 module"
+fi

--- a/recipes-kernel/kernel-modules/kernel-module-qca6564/modprobe-qca6564.conf
+++ b/recipes-kernel/kernel-modules/kernel-module-qca6564/modprobe-qca6564.conf
@@ -1,0 +1,4 @@
+# Load the wlan module with values for SDIO3.0.
+options wlan asyncintdelay=0x2 writecccr1=0xf2 writecccr1value=0xf \
+	writecccr2=0xf1 writecccr2value=0xa8 writecccr3=0xf0 \
+	writecccr3value=0xa1 writecccr4=0x15 writecccr4value=0x30

--- a/recipes-kernel/kernel-modules/kernel-module-qca6564_git.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-qca6564_git.bb
@@ -1,0 +1,57 @@
+# Copyright (C) 2019 Digi International Inc.
+
+SUMMARY = "Qualcomm QCA6564 wireless driver module"
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/ISC;md5=f3b90e78ea0cffb20bf5cca7947a896d"
+
+# Reference Qualcomm tag/version
+PV = "v4.2.89.63+${SRCPV}"
+
+SRCBRANCH = "qca6564/master"
+SRCREV = "2e780b29209ca6b0f71442be5fd36cf0ddddc661"
+
+SRC_URI = "\
+    git://github.com/digi-embedded/qcacld-2.0.git;protocol=git;branch=${SRCBRANCH} \
+    file://modprobe-qca6564.conf \
+"
+
+S = "${WORKDIR}/git"
+
+inherit module
+
+EXTRA_OEMAKE += "CONFIG_LINUX_QCMBR=y WLAN_OPEN_SOURCE=1"
+# Explicity state it is not a QC platform, if not the driver will try to remap
+# memory that is not allowed in ARMv6
+EXTRA_OEMAKE += "CONFIG_NON_QC_PLATFORM=y"
+# Flag to compile the debug version (1 - enabled, rest of values - disabled)
+EXTRA_OEMAKE += "BUILD_DEBUG_VERSION=0"
+# Flags for SDIO interface
+EXTRA_OEMAKE += "CONFIG_CLD_HL_SDIO_CORE=y"
+
+do_compile_prepend() {
+    export BUILD_VER=${PV}
+}
+
+do_install_prepend() {
+    sed -i -e "s/gVhtTxMCS=2/gVhtTxMCS=0/g" ${WORKDIR}/git/firmware_bin/WCNSS_qcom_cfg.ini
+}
+
+do_install_append() {
+    install -d ${D}${sysconfdir}/modprobe.d
+    install -m 0644 ${WORKDIR}/modprobe-qca6564.conf ${D}${sysconfdir}/modprobe.d/qca6564.conf
+
+    install -d ${D}${base_libdir}/firmware/wlan/
+    install -m 0644 ${WORKDIR}/git/firmware_bin/WCNSS_cfg.dat ${D}${base_libdir}/firmware/wlan/cfg.dat
+    install -m 0644 ${WORKDIR}/git/firmware_bin/WCNSS_qcom_cfg.ini ${D}${base_libdir}/firmware/wlan/qcom_cfg.ini
+    sed -i -e "s/gVhtTxMCS=2/gVhtTxMCS=0/g" ${D}${base_libdir}/firmware/wlan/qcom_cfg.ini
+}
+
+FILES_${PN} += " \
+    ${sysconfdir}/modprobe.d/qca6564.conf \
+    ${base_libdir}/firmware/wlan/cfg.dat \
+    ${base_libdir}/firmware/wlan/qcom_cfg.ini \
+"
+
+RRECOMMENDS_${PN} = "hostapd iw crda wireless-regdb udev-rules-digi"
+
+COMPATIBLE_MACHINE = "(ccimx6ul)"

--- a/recipes-kernel/linux-firmware-qca6564/linux-firmware-qca6564_2.4-r2.2.bb
+++ b/recipes-kernel/linux-firmware-qca6564/linux-firmware-qca6564_2.4-r2.2.bb
@@ -1,0 +1,31 @@
+# Copyright (C) 2019 Digi International Inc.
+
+SUMMARY = "Firmware files for Qualcomm's QCA6564 wireless chip"
+SECTION = "base"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://LICENCE.atheros_firmware;md5=30a14c7823beedac9fa39c64fdd01a13"
+
+SRC_URI = "ftp://ftp1.digi.com/support/digiembeddedyocto/source/${BPN}-${PV}.tar.gz"
+SRC_URI[md5sum] = "7400b74881ac499517b6ad761a54f8fc"
+SRC_URI[sha256sum] = "be3a56334764e21ee297260b6648075b7fada6f55e24a287a24e7c7d128e27ef"
+
+S = "${WORKDIR}/linux-firmware-qca6564/"
+
+do_install() {
+    install -d ${D}${base_libdir}/firmware/qca
+    install -m 0644 nvm_tlv_3.2.bin ${D}${base_libdir}/firmware/qca
+    install -m 0644 rampatch_tlv_3.2.tlv ${D}${base_libdir}/firmware/qca
+    install -m 0644 bdwlan30_US.bin ${D}${base_libdir}/firmware
+    install -m 0644 LICENCE.atheros_firmware ${D}${base_libdir}/firmware
+    install -m 0644 otp30.bin ${D}${base_libdir}/firmware
+    install -m 0644 qwlan30.bin ${D}${base_libdir}/firmware
+    install -m 0644 utf30.bin ${D}${base_libdir}/firmware
+}
+
+PACKAGES = "${PN}-bt ${PN}-wifi"
+
+FILES_${PN}-bt = "/lib/firmware/qca"
+FILES_${PN}-wifi = "/lib/firmware"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(ccimx6ul)"

--- a/recipes-kernel/linux/linux-fslc/ccimx6ul/0002-ARM-dts-imx6ul-ccimx6ulsom-Add-empty-wireless-and-bl.patch
+++ b/recipes-kernel/linux/linux-fslc/ccimx6ul/0002-ARM-dts-imx6ul-ccimx6ulsom-Add-empty-wireless-and-bl.patch
@@ -1,0 +1,32 @@
+From: Alex Gonzalez <alex.gonzalez@digi.com>
+Date: Fri, 14 Sep 2018 12:32:41 +0200
+Subject: [PATCH] ARM: dts: imx6ul: ccimx6ulsom: Add empty wireless and
+ bluetooth placeholders
+
+The vendor provided U-Boot will use these empty nodes to populate the
+MAC addresses used for both the Bluetooth and the Wireless chips.
+
+Upstream-Status: Inappropriate [vendor specific]
+
+Signed-off-by: Alex Gonzalez <alex.gonzalez@digi.com>
+---
+ arch/arm/boot/dts/imx6ul-ccimx6ulsom.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm/boot/dts/imx6ul-ccimx6ulsom.dtsi b/arch/arm/boot/dts/imx6ul-ccimx6ulsom.dtsi
+index b5781c3656d1..82fa176bf138 100644
+--- a/arch/arm/boot/dts/imx6ul-ccimx6ulsom.dtsi
++++ b/arch/arm/boot/dts/imx6ul-ccimx6ulsom.dtsi
+@@ -24,6 +24,12 @@
+ 			linux,cma-default;
+ 		};
+ 	};
++
++	bluetooth {
++	};
++
++	wireless {
++	};
+ };
+ 
+ &adc1 {

--- a/recipes-kernel/linux/linux-fslc/ccimx6ul/0003-net-wireless-Export-regulatory_hint_user.patch
+++ b/recipes-kernel/linux/linux-fslc/ccimx6ul/0003-net-wireless-Export-regulatory_hint_user.patch
@@ -1,0 +1,77 @@
+From: Alex Gonzalez <alex.gonzalez@digi.com>
+Date: Mon, 10 Sep 2018 13:38:40 +0200
+Subject: [PATCH] net: wireless: Export regulatory_hint_user()
+
+The QCA6564 driver makes use of this kernel API when built with
+the QCA_VENDOR_KERNEL flag.
+
+Signed-off-by: Alex Gonzalez <alex.gonzalez@digi.com>
+---
+ include/net/cfg80211.h | 26 ++++++++++++++++++++++++++
+ net/wireless/reg.c     |  1 +
+ net/wireless/reg.h     |  3 ---
+ 3 files changed, 27 insertions(+), 3 deletions(-)
+
+diff --git a/include/net/cfg80211.h b/include/net/cfg80211.h
+index e0c41eb1c860..84d47ac0cea4 100644
+--- a/include/net/cfg80211.h
++++ b/include/net/cfg80211.h
+@@ -5111,6 +5111,32 @@ int regulatory_set_wiphy_regd_sync_rtnl(struct wiphy *wiphy,
+ 					struct ieee80211_regdomain *rd);
+ 
+ /**
++ * regulatory_hint_user - hint to the wireless core a regulatory domain
++ * which the driver has received from an application
++ * @alpha2: the ISO/IEC 3166 alpha2 the driver claims its regulatory domain
++ *	should be in. If @rd is set this should be NULL. Note that if you
++ *	set this to NULL you should still set rd->alpha2 to some accepted
++ *	alpha2.
++ * @user_reg_hint_type: the type of user regulatory hint.
++ *
++ * Wireless drivers can use this function to hint to the wireless core
++ * the current regulatory domain as specified by trusted applications,
++ * it is the driver's responsibilty to estbalish which applications it
++ * trusts.
++ *
++ * The wiphy should be registered to cfg80211 prior to this call.
++ * For cfg80211 drivers this means you must first use wiphy_register(),
++ * for mac80211 drivers you must first use ieee80211_register_hw().
++ *
++ * Drivers should check the return value, its possible you can get
++ * an -ENOMEM or an -EINVAL.
++ *
++ * Return: 0 on success. -ENOMEM, -EINVAL.
++ */
++int regulatory_hint_user(const char *alpha2,
++			 enum nl80211_user_reg_hint_type user_reg_hint_type);
++
++/**
+  * wiphy_apply_custom_regulatory - apply a custom driver regulatory domain
+  * @wiphy: the wireless device we want to process the regulatory domain on
+  * @regd: the custom regulatory domain to use for this wiphy
+diff --git a/net/wireless/reg.c b/net/wireless/reg.c
+index dd58b9909ac9..816a8a25b06f 100644
+--- a/net/wireless/reg.c
++++ b/net/wireless/reg.c
+@@ -2912,6 +2912,7 @@ int regulatory_hint_user(const char *alpha2,
+ 
+ 	return 0;
+ }
++EXPORT_SYMBOL(regulatory_hint_user);
+ 
+ int regulatory_hint_indoor(bool is_indoor, u32 portid)
+ {
+diff --git a/net/wireless/reg.h b/net/wireless/reg.h
+index 9ceeb5f3a7cb..92de47dec466 100644
+--- a/net/wireless/reg.h
++++ b/net/wireless/reg.h
+@@ -31,9 +31,6 @@ bool is_world_regdom(const char *alpha2);
+ bool reg_supported_dfs_region(enum nl80211_dfs_regions dfs_region);
+ enum nl80211_dfs_regions reg_get_dfs_region(struct wiphy *wiphy);
+ 
+-int regulatory_hint_user(const char *alpha2,
+-			 enum nl80211_user_reg_hint_type user_reg_hint_type);
+-
+ /**
+  * regulatory_hint_indoor - hint operation in indoor env. or not
+  * @is_indoor: if true indicates that user space thinks that the

--- a/recipes-kernel/linux/linux-fslc/ccimx6ul/0004-net-wireless-Allow-for-firmware-to-handle-DFS.patch
+++ b/recipes-kernel/linux/linux-fslc/ccimx6ul/0004-net-wireless-Allow-for-firmware-to-handle-DFS.patch
@@ -1,0 +1,62 @@
+From: Alex Gonzalez <alex.gonzalez@digi.com>
+Date: Fri, 7 Sep 2018 13:12:14 +0200
+Subject: [PATCH] net: wireless: Allow for firmware to handle DFS
+
+The QCA6564 driver makes use of this functionality when compiled with
+the QCA_VENDOR_KERNEL flag.
+
+Signed-off-by: Alex Gonzalez <alex.gonzalez@digi.com>
+---
+ include/net/cfg80211.h | 2 ++
+ net/wireless/chan.c    | 3 ++-
+ net/wireless/nl80211.c | 3 +++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/include/net/cfg80211.h b/include/net/cfg80211.h
+index 84d47ac0cea4..3082f6bf047d 100644
+--- a/include/net/cfg80211.h
++++ b/include/net/cfg80211.h
+@@ -3740,6 +3740,7 @@ struct cfg80211_ops {
+  *	beaconing mode (AP, IBSS, Mesh, ...).
+  * @WIPHY_FLAG_HAS_STATIC_WEP: The device supports static WEP key installation
+  *	before connection.
++ * @WIPHY_FLAG_DFS_OFFLOAD: The driver handles all the DFS related operations.
+  */
+ enum wiphy_flags {
+ 	/* use hole at 0 */
+@@ -3766,6 +3767,7 @@ enum wiphy_flags {
+ 	WIPHY_FLAG_SUPPORTS_5_10_MHZ		= BIT(22),
+ 	WIPHY_FLAG_HAS_CHANNEL_SWITCH		= BIT(23),
+ 	WIPHY_FLAG_HAS_STATIC_WEP		= BIT(24),
++	WIPHY_FLAG_DFS_OFFLOAD                  = BIT(25),
+ };
+ 
+ /**
+diff --git a/net/wireless/chan.c b/net/wireless/chan.c
+index 7dc1bbd0888f..2ef1f908408f 100644
+--- a/net/wireless/chan.c
++++ b/net/wireless/chan.c
+@@ -321,7 +321,8 @@ static int cfg80211_get_chans_dfs_required(struct wiphy *wiphy,
+ 		if (!c)
+ 			return -EINVAL;
+ 
+-		if (c->flags & IEEE80211_CHAN_RADAR)
++		if ((c->flags & IEEE80211_CHAN_RADAR) &&
++		    !(wiphy->flags & WIPHY_FLAG_DFS_OFFLOAD))
+ 			return 1;
+ 	}
+ 	return 0;
+diff --git a/net/wireless/nl80211.c b/net/wireless/nl80211.c
+index d91a408db113..930670ccfa59 100644
+--- a/net/wireless/nl80211.c
++++ b/net/wireless/nl80211.c
+@@ -7956,6 +7956,9 @@ static int nl80211_start_radar_detection(struct sk_buff *skb,
+ 	if (netif_carrier_ok(dev))
+ 		return -EBUSY;
+ 
++	if (rdev->wiphy.flags & WIPHY_FLAG_DFS_OFFLOAD)
++		return -EOPNOTSUPP;
++
+ 	if (wdev->cac_started)
+ 		return -EBUSY;
+ 

--- a/recipes-kernel/linux/linux-fslc/ccimx6ul/0005-net-wireless-Add-cfg80211_is_gratuitous_arp_unsolici.patch
+++ b/recipes-kernel/linux/linux-fslc/ccimx6ul/0005-net-wireless-Add-cfg80211_is_gratuitous_arp_unsolici.patch
@@ -1,0 +1,95 @@
+From: Alex Gonzalez <alex.gonzalez@digi.com>
+Date: Fri, 7 Sep 2018 13:01:54 +0200
+Subject: [PATCH] net: wireless: Add
+ cfg80211_is_gratuitous_arp_unsolicited_na()
+
+The QCA6564 driver makes use of this call when compiled with the
+QCA_VENDOR_KERNEL flag.
+
+Signed-off-by: Alex Gonzalez <alex.gonzalez@digi.com>
+---
+ include/net/cfg80211.h | 10 ++++++++++
+ net/wireless/util.c    | 52 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 62 insertions(+)
+
+diff --git a/include/net/cfg80211.h b/include/net/cfg80211.h
+index 3082f6bf047d..42445bd1c26a 100644
+--- a/include/net/cfg80211.h
++++ b/include/net/cfg80211.h
+@@ -6736,6 +6736,16 @@ void cfg80211_crit_proto_stopped(struct wireless_dev *wdev, gfp_t gfp);
+ unsigned int ieee80211_get_num_supported_channels(struct wiphy *wiphy);
+ 
+ /**
++ * cfg80211_is_gratuitous_arp_unsolicited_na - packet is grat. ARP/unsol. NA
++ * @skb: the input packet, must be an ethernet frame already
++ *
++ * Return: %true if the packet is a gratuitous ARP or unsolicited NA packet.
++ * This is used to drop packets that shouldn't occur because the AP implements
++ * a proxy service.
++ */
++bool cfg80211_is_gratuitous_arp_unsolicited_na(struct sk_buff *skb);
++
++/**
+  * cfg80211_check_combinations - check interface combinations
+  *
+  * @wiphy: the wiphy
+diff --git a/net/wireless/util.c b/net/wireless/util.c
+index ec30e3732c7b..abcefae39e81 100644
+--- a/net/wireless/util.c
++++ b/net/wireless/util.c
+@@ -2061,3 +2061,55 @@ int ieee80211_get_vht_max_nss(struct ieee80211_vht_cap *cap,
+ 	return max_vht_nss;
+ }
+ EXPORT_SYMBOL(ieee80211_get_vht_max_nss);
++
++bool cfg80211_is_gratuitous_arp_unsolicited_na(struct sk_buff *skb)
++{
++	const struct ethhdr *eth = (void *)skb->data;
++
++	const struct {
++		struct arphdr hdr;
++		u8 ar_sha[ETH_ALEN];
++		u8 ar_sip[4];
++		u8 ar_tha[ETH_ALEN];
++		u8 ar_tip[4];
++	} __packed * arp;
++
++	const struct ipv6hdr *ipv6;
++	const struct icmp6hdr *icmpv6;
++
++	switch (eth->h_proto) {
++	case cpu_to_be16(ETH_P_ARP):
++		/* can't say - but will probably be dropped later anyway */
++		if (!pskb_may_pull(skb, sizeof(*eth) + sizeof(*arp)))
++			return false;
++
++		arp = (void *)(eth + 1);
++
++		if ((arp->hdr.ar_op == cpu_to_be16(ARPOP_REPLY) ||
++		     arp->hdr.ar_op == cpu_to_be16(ARPOP_REQUEST)) &&
++		    !memcmp(arp->ar_sip, arp->ar_tip, sizeof(arp->ar_sip)))
++			return true;
++		break;
++	case cpu_to_be16(ETH_P_IPV6):
++		/* can't say - but will probably be dropped later anyway */
++		if (!pskb_may_pull(skb, sizeof(*eth) + sizeof(*ipv6) +
++					sizeof(*icmpv6)))
++			return false;
++
++		ipv6 = (void *)(eth + 1);
++		icmpv6 = (void *)(ipv6 + 1);
++
++		if (icmpv6->icmp6_type == NDISC_NEIGHBOUR_ADVERTISEMENT &&
++		    !memcmp(&ipv6->saddr, &ipv6->daddr, sizeof(ipv6->saddr)))
++			return true;
++		break;
++	default:
++		/* no need to support other protocols, proxy service isn't
++		 * specified for any others
++		 */
++		break;
++	}
++
++	return false;
++}
++EXPORT_SYMBOL(cfg80211_is_gratuitous_arp_unsolicited_na);

--- a/recipes-kernel/linux/linux-fslc/ccimx6ul/0006-linux-crypto-caam-set-hwrng-quality.patch
+++ b/recipes-kernel/linux/linux-fslc/ccimx6ul/0006-linux-crypto-caam-set-hwrng-quality.patch
@@ -1,0 +1,26 @@
+From: Jose Diaz de Grenu <Jose.DiazdeGrenu@digi.com>
+Date: Wed, 27 Jun 2018 17:39:11 +0200
+Subject: [PATCH] linux: crypto: caam set hwrng quality
+
+According to the i.MX6 Security Reference Manual it is a NIST
+certifiable RNG, so set high quality to let the HWRNG framework
+automatically use it.
+
+Signed-off-by: Jose Diaz de Grenu <Jose.DiazdeGrenu@digi.com>
+Signed-off-by: Alex Gonzalez <alex.gonzalez@digi.com>
+---
+ drivers/crypto/caam/caamrng.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/crypto/caam/caamrng.c b/drivers/crypto/caam/caamrng.c
+index fde07d4ff019..ddca16941640 100644
+--- a/drivers/crypto/caam/caamrng.c
++++ b/drivers/crypto/caam/caamrng.c
+@@ -292,6 +292,7 @@ static struct hwrng caam_rng = {
+ 	.name		= "rng-caam",
+ 	.cleanup	= caam_cleanup,
+ 	.read		= caam_read,
++	.quality	= 1024,
+ };
+ 
+ static void __exit caam_rng_exit(void)

--- a/recipes-kernel/linux/linux-fslc_%.bbappend
+++ b/recipes-kernel/linux/linux-fslc_%.bbappend
@@ -10,7 +10,24 @@ SRC_URI_append_imx6qdl-variscite-som_use-mainline-bsp = " \
 
 SRC_URI_append_ccimx6ul = " \
     file://0001-MLK-11719-4-mtd-gpmi-change-the-BCH-layout-setting-f.patch \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'file://0002-ARM-dts-imx6ul-ccimx6ulsom-Add-empty-wireless-and-bl.patch', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'file://0003-net-wireless-Export-regulatory_hint_user.patch', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'file://0004-net-wireless-Allow-for-firmware-to-handle-DFS.patch', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'file://0005-net-wireless-Add-cfg80211_is_gratuitous_arp_unsolici.patch', '', d)} \
+    file://0006-linux-crypto-caam-set-hwrng-quality.patch \
 "
+
+do_configure_prepend_ccimx6ul() {
+    if ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'true', 'false', d)}; then
+        kernel_conf_variable HOSTAP m
+        kernel_conf_variable PROVE_LOCKING n
+        sed -e "${CONF_SED_SCRIPT}" < '${WORKDIR}/defconfig' >> '${B}/.config'
+    fi
+    if ${@bb.utils.contains('MACHINE_FEATURES', 'bluetooth', 'true', 'false', d)}; then
+        kernel_conf_variable BT_RFCOMM y
+        sed -e "${CONF_SED_SCRIPT}" < '${WORKDIR}/defconfig' >> '${B}/.config'
+    fi
+}
 
 do_configure_prepend_imx6qdl-variscite-som() {
     cp ${WORKDIR}/imx6*-var*.dts* ${S}/arch/arm/boot/dts


### PR DESCRIPTION
The ConnectCore 6UL SOM contains a Qualcomm QCA6564A chipset with the following features:

- Dual Band 5GHz 802.11ac or 2.4/5GHz 802.11n Wireless Local Area Network (US regulatory domain)
- Open, Wi-Fi Protected Access (WPA) and Wi-Fi Protected Access 2 (WPA2 (personal and enterprise) authentications
- Data encryption using Advanced Encryption Standard (AES) or Temporal Key Integrity Protocol (TKIP)
- Station and SoftAP concurrent modes
- Bluetooth (BT) 4.2

This commit adds software support for it.
