### PR TITLE
conf/layer.conf: Drop sumo and thud support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "fsl-arm-extra"
 BBFILE_PATTERN_fsl-arm-extra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_fsl-arm-extra = "4"
 
-LAYERSERIES_COMPAT_fsl-arm-extra = "sumo thud warrior"
+LAYERSERIES_COMPAT_fsl-arm-extra = "warrior"
 LAYERDEPENDS_fsl-arm-extra = "core freescale-layer"


### PR DESCRIPTION
If you want to use theses branches, use the respective platform.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>