### PR TITLE
imx7s-warp: Update settings to use U-Boot 2019.04

### DIFF
--- a/conf/machine/imx7s-warp.conf
+++ b/conf/machine/imx7s-warp.conf
@@ -13,6 +13,9 @@ MACHINE_FEATURES += " wifi bluetooth"
 
 KERNEL_DEVICETREE = "imx7s-warp.dtb"
 
+UBOOT_BINARY = "u-boot-dtb.imx"
+UBOOT_MAKE_TARGET = ""
+
 UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "warp7_defconfig,sdcard"
 


### PR DESCRIPTION
Since DM conversion, we have to adjust the binary name.

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>