### PR TITLE
imx7d-pico: Update settings for U-Boot 2019.07

### DIFF
--- a/conf/machine/imx7d-pico.conf
+++ b/conf/machine/imx7d-pico.conf
@@ -18,7 +18,7 @@ KERNEL_DEVICETREE = " \
 "
 
 SPL_BINARY = "SPL"
-UBOOT_SUFFIX = "img"
+UBOOT_BINARY = "u-boot-dtb.img"
 UBOOT_MAKE_TARGET = ""
 
 UBOOT_CONFIG ??= "dwarf hobbit nymph pi generic"
@@ -42,6 +42,6 @@ MACHINE_EXTRA_RRECOMMENDS += " \
   bcm4339-nvram-config \
 "
 
-WKS_FILES ?= "imx-uboot-spl.wks"
+WKS_FILES ?= "imx-uboot-spl.wks.in"
 WKS_FILE_DEPENDS ?= ""
 IMAGE_FSTYPES = "wic.bmap wic.xz ext4.gz"


### PR DESCRIPTION
Since DM conversion, we have to adjust the binary name.
Also changes wks file for fix generation image

This PR depends on https://github.com/Freescale/meta-freescale/pull/128
Signed-off-by: Joris Offouga <offougajoris@gmail.com>