### PR TITLE
Fix WKS_FILE to use files with .in extension

### DIFF
--- a/conf/machine/cgtqmx6.conf
+++ b/conf/machine/cgtqmx6.conf
@@ -16,7 +16,7 @@ UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"
 UBOOT_CONFIG ??= "cgtqmx6"
 UBOOT_CONFIG[cgtqmx6] = "cgtqmx6eval_defconfig"
-WKS_FILE = "imx-uboot-spl-bootpart.wks"
+WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
 # Use linux kernel QMX6
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-congatec"

--- a/conf/machine/cubox-i.conf
+++ b/conf/machine/cubox-i.conf
@@ -23,7 +23,7 @@ UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "mx6cuboxi_defconfig,sdcard"
 UENV_FILENAME = "uEnv-${MACHINE}.txt"
 SPL_BINARY = "SPL"
-WKS_FILES = "imx-uboot-spl.wks"
+WKS_FILES = "imx-uboot-spl.wks.in"
 
 UBOOT_EXTLINUX = "1"
 UBOOT_EXTLINUX_ROOT = "root=PARTUUID=${uuid}"

--- a/conf/machine/imx6qdl-variscite-som.conf
+++ b/conf/machine/imx6qdl-variscite-som.conf
@@ -34,7 +34,7 @@ KERNEL_IMAGETYPE = "uImage"
 UBOOT_SPL_BUILD = "yes"
 UBOOT_MAKE_TARGET = "all"
 UBOOT_SUFFIX = "img"
-WKS_FILE = "imx-uboot-spl-bootpart.wks"
+WKS_FILE = "imx-uboot-spl-bootpart.wks.in"
 
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-variscite"
 PREFERRED_PROVIDER_u-boot = "u-boot-variscite"

--- a/conf/machine/imx6ul-pico.conf
+++ b/conf/machine/imx6ul-pico.conf
@@ -39,6 +39,6 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
 
 MACHINE_FEATURES += "wifi bluetooth"
 
-WKS_FILES ?= "imx-uboot-spl.wks"
+WKS_FILES ?= "imx-uboot-spl.wks.in"
 WKS_FILE_DEPENDS ?= ""
 IMAGE_FSTYPES = "wic.bmap wic.xz ext4.gz"

--- a/conf/machine/wandboard.conf
+++ b/conf/machine/wandboard.conf
@@ -48,4 +48,4 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
     u-boot-fslc \
 "
 
-WKS_FILES = "imx-uboot-spl.wks"
+WKS_FILES = "imx-uboot-spl.wks.in"


### PR DESCRIPTION
meta-freescale commit 6be9d197386b5c3bd72023981df805d42f87684c
renamed imx-uboot-spl-bootpart.wks to imx-uboot-spl-bootpart.wks.in
The .in extension in wks files allows bitbake variables to be used in
kickstarter files. Set WKS_FILES for all machines to match this new
filename.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>