### PR TITLE
meta: change "+=" to "_append" for use-mainline-bsp overrides

### DIFF
--- a/conf/machine/apalis-imx6.conf
+++ b/conf/machine/apalis-imx6.conf
@@ -13,7 +13,7 @@ PREFERRED_PROVIDER_virtual/kernel ??= "linux-toradex"
 PREFERRED_PROVIDER_virtual/kernel_use-mainline-bsp ??= "linux-fslc"
 KERNEL_DEVICETREE += "imx6q-apalis-eval.dtb imx6q-apalis-ixora.dtb \
                       imx6q-apalis-ixora-v1.1.dtb"
-KERNEL_DEVICETREE_use-mainline-bsp += "imx6q-apalis-ixora.dtb"
+KERNEL_DEVICETREE_append_use-mainline-bsp = " imx6q-apalis-ixora.dtb"
 KERNEL_IMAGETYPE = "zImage"
 # The kernel lives in a seperate FAT partition, don't deploy it in /boot/
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""

--- a/conf/machine/colibri-imx6.conf
+++ b/conf/machine/colibri-imx6.conf
@@ -13,7 +13,7 @@ PREFERRED_PROVIDER_virtual/kernel ??= "linux-toradex"
 PREFERRED_PROVIDER_virtual/kernel_use-mainline-bsp ??= "linux-fslc"
 KERNEL_DEVICETREE += "imx6dl-colibri-eval-v3.dtb imx6dl-colibri-cam-eval-v3.dtb \
                       imx6dl-colibri-aster.dtb"
-KERNEL_DEVICETREE_use-mainline-bsp += "imx6dl-colibri-eval-v3.dtb"
+KERNEL_DEVICETREE_append_use-mainline-bsp = " imx6dl-colibri-eval-v3.dtb"
 KERNEL_IMAGETYPE = "zImage"
 # The kernel lives in a seperate FAT partition, don't deploy it in /boot/
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""


### PR DESCRIPTION
The "KERNEL_DEVICETREE_use-mainline-bsp +=" would override any other
assignment like:
- "KERNEL_DEVICETREE +="
- "KERNEL_DEVICETREE ="
- "KERNEL_DEVICETREE ?="
- "KERNEL_DEVICETREE ??="

change it to "_append" could fix the problem.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>