### PR TITLE
apalis-imx6: build all device trees available upstream

### DIFF
--- a/conf/machine/apalis-imx6.conf
+++ b/conf/machine/apalis-imx6.conf
@@ -13,7 +13,6 @@ PREFERRED_PROVIDER_virtual/kernel ??= "linux-toradex"
 PREFERRED_PROVIDER_virtual/kernel_use-mainline-bsp ??= "linux-fslc"
 KERNEL_DEVICETREE += "imx6q-apalis-eval.dtb imx6q-apalis-ixora.dtb \
                       imx6q-apalis-ixora-v1.1.dtb"
-KERNEL_DEVICETREE_append_use-mainline-bsp = " imx6q-apalis-ixora.dtb"
 KERNEL_IMAGETYPE = "zImage"
 # The kernel lives in a seperate FAT partition, don't deploy it in /boot/
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""


### PR DESCRIPTION
At least since 4.14 all device trees are available in upsteram Linux
as well so drop the unnecessary use-mainline-bsp override.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>