### PR TITLE
colibri-imx6.conf: drop _append overrides

### DIFF
--- a/conf/machine/colibri-imx6.conf
+++ b/conf/machine/colibri-imx6.conf
@@ -13,7 +13,7 @@ PREFERRED_PROVIDER_virtual/kernel ??= "linux-toradex"
 PREFERRED_PROVIDER_virtual/kernel_use-mainline-bsp ??= "linux-fslc"
 KERNEL_DEVICETREE += "imx6dl-colibri-eval-v3.dtb imx6dl-colibri-cam-eval-v3.dtb \
                       imx6dl-colibri-aster.dtb"
-KERNEL_DEVICETREE_append_use-mainline-bsp = " imx6dl-colibri-eval-v3.dtb"
+KERNEL_DEVICETREE_use-mainline-bsp = "imx6dl-colibri-eval-v3.dtb"
 KERNEL_IMAGETYPE = "zImage"
 # The kernel lives in a seperate FAT partition, don't deploy it in /boot/
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""


### PR DESCRIPTION
A regress was introduced by me in commit 9a96fb93:
[ meta: change "+=" to "_append" for use-mainline-bsp overrides ]

a "+=" operator was changed to "_append" in that commit which is wrong
because that makes some non-existing dtb files being put into
KERNEL_DEVICETREE, hence leads build issue for mainline kernel.

Drop the "_append", change "+=" to "=" would be enough.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>