### PR TITLE
u-boot-boundary: add "B" to u-boot-boundary-common_2018.07.inc

### DIFF
--- a/recipes-bsp/u-boot/u-boot-boundary-common_2018.07.inc
+++ b/recipes-bsp/u-boot/u-boot-boundary-common_2018.07.inc
@@ -9,5 +9,5 @@ SRCBRANCH = "boundary-v2018.07"
 SRC_URI = "git://github.com/boundarydevices/u-boot-imx6.git;branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"
-
+B = "${WORKDIR}/build"
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
In upstream openembedded-core, the definition for the B variable moved from
u-boot.inc to u-boot-common.inc. None of the recipes in this layer use
upstream's u-boot-common.inc, so add the B to the *common* include files here
so u-boot continues to build. See:

http://cgit.openembedded.org/openembedded-core/commit/meta/recipes-bsp/u-boot?id=26023b6b0f897842fd98b3e10a8acd5b3ad8f418&h=master

Fixes:

meta-freescale-3rdparty/recipes-bsp/u-boot/u-boot-boundary_2018.07.bb:do_compile) failed with exit code '1'

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>