### PR TITLE
linux-boundary: Fix GCC9 compiler attribute related compile errors

### DIFF
--- a/recipes-kernel/linux/linux-boundary/0001-Compiler-Attributes-add-support-for-__copy-gcc-9.patch
+++ b/recipes-kernel/linux/linux-boundary/0001-Compiler-Attributes-add-support-for-__copy-gcc-9.patch
@@ -1,0 +1,98 @@
+From 2a0f719db71c69f5a04fcfc164f12f58f3ee7703 Mon Sep 17 00:00:00 2001
+From: Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>
+Date: Fri, 8 Feb 2019 23:51:05 +0100
+Subject: [PATCH] Compiler Attributes: add support for __copy (gcc >= 9)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit c0d9782f5b6d7157635ae2fd782a4b27d55a6013 upstream.
+
+From the GCC manual:
+
+  copy
+  copy(function)
+
+    The copy attribute applies the set of attributes with which function
+    has been declared to the declaration of the function to which
+    the attribute is applied. The attribute is designed for libraries
+    that define aliases or function resolvers that are expected
+    to specify the same set of attributes as their targets. The copy
+    attribute can be used with functions, variables, or types. However,
+    the kind of symbol to which the attribute is applied (either
+    function or variable) must match the kind of symbol to which
+    the argument refers. The copy attribute copies only syntactic and
+    semantic attributes but not attributes that affect a symbol’s
+    linkage or visibility such as alias, visibility, or weak.
+    The deprecated attribute is also not copied.
+
+  https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
+
+The upcoming GCC 9 release extends the -Wmissing-attributes warnings
+(enabled by -Wall) to C and aliases: it warns when particular function
+attributes are missing in the aliases but not in their target, e.g.:
+
+    void __cold f(void) {}
+    void __alias("f") g(void);
+
+diagnoses:
+
+    warning: 'g' specifies less restrictive attribute than
+    its target 'f': 'cold' [-Wmissing-attributes]
+
+Using __copy(f) we can copy the __cold attribute from f to g:
+
+    void __cold f(void) {}
+    void __copy(f) __alias("f") g(void);
+
+This attribute is most useful to deal with situations where an alias
+is declared but we don't know the exact attributes the target has.
+
+For instance, in the kernel, the widely used module_init/exit macros
+define the init/cleanup_module aliases, but those cannot be marked
+always as __init/__exit since some modules do not have their
+functions marked as such.
+
+Suggested-by: Martin Sebor <msebor@gcc.gnu.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Signed-off-by: Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ include/linux/compiler-gcc.h   | 4 ++++
+ include/linux/compiler_types.h | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/include/linux/compiler-gcc.h b/include/linux/compiler-gcc.h
+index a8ff0ca..3ebee1c 100644
+--- a/include/linux/compiler-gcc.h
++++ b/include/linux/compiler-gcc.h
+@@ -345,6 +345,10 @@
+ 
+ #endif	/* gcc version >= 40000 specific checks */
+ 
++#if GCC_VERSION >= 90100
++#define __copy(symbol)                 __attribute__((__copy__(symbol)))
++#endif
++
+ #if !defined(__noclone)
+ #define __noclone	/* not needed */
+ #endif
+diff --git a/include/linux/compiler_types.h b/include/linux/compiler_types.h
+index c2ded31..2b8ed70 100644
+--- a/include/linux/compiler_types.h
++++ b/include/linux/compiler_types.h
+@@ -261,6 +261,10 @@ struct ftrace_likely_data {
+ #define __visible
+ #endif
+ 
++#ifndef __copy
++# define __copy(symbol)
++#endif
++
+ #ifndef __nostackprotector
+ # define __nostackprotector
+ #endif
+-- 
+2.7.4
+

--- a/recipes-kernel/linux/linux-boundary/0002-include-linux-module.h-copy-__init-__exit-attrs-to-i.patch
+++ b/recipes-kernel/linux/linux-boundary/0002-include-linux-module.h-copy-__init-__exit-attrs-to-i.patch
@@ -1,0 +1,83 @@
+From 9468870f7cbdb4d7ca828d02d4ff507c01fe591d Mon Sep 17 00:00:00 2001
+From: Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>
+Date: Sat, 19 Jan 2019 20:59:34 +0100
+Subject: [PATCH] include/linux/module.h: copy __init/__exit attrs to
+ init/cleanup_module
+
+commit a6e60d84989fa0e91db7f236eda40453b0e44afa upstream.
+
+The upcoming GCC 9 release extends the -Wmissing-attributes warnings
+(enabled by -Wall) to C and aliases: it warns when particular function
+attributes are missing in the aliases but not in their target.
+
+In particular, it triggers for all the init/cleanup_module
+aliases in the kernel (defined by the module_init/exit macros),
+ending up being very noisy.
+
+These aliases point to the __init/__exit functions of a module,
+which are defined as __cold (among other attributes). However,
+the aliases themselves do not have the __cold attribute.
+
+Since the compiler behaves differently when compiling a __cold
+function as well as when compiling paths leading to calls
+to __cold functions, the warning is trying to point out
+the possibly-forgotten attribute in the alias.
+
+In order to keep the warning enabled, we decided to silence
+this case. Ideally, we would mark the aliases directly
+as __init/__exit. However, there are currently around 132 modules
+in the kernel which are missing __init/__exit in their init/cleanup
+functions (either because they are missing, or for other reasons,
+e.g. the functions being called from somewhere else); and
+a section mismatch is a hard error.
+
+A conservative alternative was to mark the aliases as __cold only.
+However, since we would like to eventually enforce __init/__exit
+to be always marked,  we chose to use the new __copy function
+attribute (introduced by GCC 9 as well to deal with this).
+With it, we copy the attributes used by the target functions
+into the aliases. This way, functions that were not marked
+as __init/__exit won't have their aliases marked either,
+and therefore there won't be a section mismatch.
+
+Note that the warning would go away marking either the extern
+declaration, the definition, or both. However, we only mark
+the definition of the alias, since we do not want callers
+(which only see the declaration) to be compiled as if the function
+was __cold (and therefore the paths leading to those calls
+would be assumed to be unlikely).
+
+Link: https://lore.kernel.org/lkml/20190123173707.GA16603@gmail.com/
+Link: https://lore.kernel.org/lkml/20190206175627.GA20399@gmail.com/
+Suggested-by: Martin Sebor <msebor@gcc.gnu.org>
+Acked-by: Jessica Yu <jeyu@kernel.org>
+Signed-off-by: Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ include/linux/module.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/linux/module.h b/include/linux/module.h
+index c710446..9915397 100644
+--- a/include/linux/module.h
++++ b/include/linux/module.h
+@@ -130,13 +130,13 @@ extern void cleanup_module(void);
+ #define module_init(initfn)					\
+ 	static inline initcall_t __maybe_unused __inittest(void)		\
+ 	{ return initfn; }					\
+-	int init_module(void) __attribute__((alias(#initfn)));
++	int init_module(void) __copy(initfn) __attribute__((alias(#initfn)));
+ 
+ /* This is only required if you want to be unloadable. */
+ #define module_exit(exitfn)					\
+ 	static inline exitcall_t __maybe_unused __exittest(void)		\
+ 	{ return exitfn; }					\
+-	void cleanup_module(void) __attribute__((alias(#exitfn)));
++	void cleanup_module(void) __copy(exitfn) __attribute__((alias(#exitfn)));
+ 
+ #endif
+ 
+-- 
+2.7.4
+

--- a/recipes-kernel/linux/linux-boundary_4.14.x.bb
+++ b/recipes-kernel/linux/linux-boundary_4.14.x.bb
@@ -6,6 +6,8 @@ require recipes-kernel/linux/linux-imx.inc
 SUMMARY = "Linux kernel for Boundary Devices boards"
 
 SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH} \
+           file://0001-Compiler-Attributes-add-support-for-__copy-gcc-9.patch \
+           file://0002-include-linux-module.h-copy-__init-__exit-attrs-to-i.patch \
 "
 
 LOCALVERSION = "-2.0.0-ga+yocto"


### PR DESCRIPTION
These patches are originally from meta-freescale, commit 075681e8 , and
were modified slightly to apply to kernel 4.14.

This fixes errors while building other modules, especially
kernel-module-imx-gpu-viv, which otherwise produces compile errors like:

    | [...]tmp/work-shared/nitrogen8m/kernel-source/include/linux/module.h:131:6: error: 'init_module' specifies less restrictive attribute than its target 'gpu_init': 'cold' [-Werror=missing-attributes]
    |   131 |  int init_module(void) __attribute__((alias(#initfn)));
    |       |      ^~~~~~~~~~~
    | [...]tmp/work/nitrogen8m-poky-linux/kernel-module-imx-gpu-viv/6.4.0.p1.0-r0/git/src/hal/os/linux/kernel/gc_hal_kernel_driver.c:1445:1: note: in expansion of macro 'module_init'
    |  1445 | module_init(gpu_init);
    |       | ^~~~~~~~~~~
    | [...]tmp/work/nitrogen8m-poky-linux/kernel-module-imx-gpu-viv/6.4.0.p1.0-r0/git/src/hal/os/linux/kernel/gc_hal_kernel_driver.c:1411:19: note: 'init_module' target declared here
    |  1411 | static int __init gpu_init(void)
    |       |                   ^~~~~~~~
    | In file included from [...]tmp/work/nitrogen8m-poky-linux/kernel-module-imx-gpu-viv/6.4.0.p1.0-r0/git/src/hal/os/linux/kernel/gc_hal_kernel_linux.h:61,
    |                  from [...]tmp/work/nitrogen8m-poky-linux/kernel-module-imx-gpu-viv/6.4.0.p1.0-r0/git/src/hal/os/linux/kernel/gc_hal_kernel_driver.c:61:
    | [...]tmp/work-shared/nitrogen8m/kernel-source/include/linux/module.h:137:7: error: 'cleanup_module' specifies less restrictive attribute than its target 'gpu_exit': 'cold' [-Werror=missing-attributes]
    |   137 |  void cleanup_module(void) __attribute__((alias(#exitfn)));
    |       |       ^~~~~~~~~~~~~~
    | [...]tmp/work/nitrogen8m-poky-linux/kernel-module-imx-gpu-viv/6.4.0.p1.0-r0/git/src/hal/os/linux/kernel/gc_hal_kernel_driver.c:1446:1: note: in expansion of macro 'module_exit'
    |  1446 | module_exit(gpu_exit);
    |       | ^~~~~~~~~~~
    | [...]tmp/work/nitrogen8m-poky-linux/kernel-module-imx-gpu-viv/6.4.0.p1.0-r0/git/src/hal/os/linux/kernel/gc_hal_kernel_driver.c:1437:20: note: 'cleanup_module' target declared here
    |  1437 | static void __exit gpu_exit(void)
    |       |                    ^~~~~~~~