### PR TITLE
conf/layer.conf: Rename BBFILE_COLLECTIONS to match layer name

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,9 +5,9 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "fsl-arm-extra"
-BBFILE_PATTERN_fsl-arm-extra := "^${LAYERDIR}/"
-BBFILE_PRIORITY_fsl-arm-extra = "4"
+BBFILE_COLLECTIONS += "freescale-3rdparty"
+BBFILE_PATTERN_freescale-3rdparty := "^${LAYERDIR}/"
+BBFILE_PRIORITY_freescale-3rdparty = "4"
 
-LAYERSERIES_COMPAT_fsl-arm-extra = "zeus dunfell"
-LAYERDEPENDS_fsl-arm-extra = "core freescale-layer"
+LAYERSERIES_COMPAT_freescale-3rdparty = "zeus dunfell"
+LAYERDEPENDS_freescale-3rdparty = "core freescale-layer"


### PR DESCRIPTION
BBFILE_COLLECTIONS was using the old layer name, rename to match
the new name.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>