### PR TITLE
u-boot-toradex: build nand padded binary

### DIFF
--- a/conf/machine/colibri-imx6ull.conf
+++ b/conf/machine/colibri-imx6ull.conf
@@ -21,7 +21,7 @@ PREFERRED_PROVIDER_u-boot-fw-utils ?= "u-boot-toradex-fw-utils"
 PREFERRED_RPROVIDER_u-boot-fw-utils ?= "u-boot-toradex-fw-utils"
 
 UBOOT_BINARY = "u-boot-nand.imx"
-UBOOT_MAKE_TARGET = "u-boot-nand.imx"
+UBOOT_MAKE_TARGET = "u-boot.imx"
 UBOOT_MACHINE ?= "colibri-imx6ull_defconfig"
 
 IMAGE_FSTYPES += "tar.xz"

--- a/conf/machine/colibri-imx7-nand.conf
+++ b/conf/machine/colibri-imx7-nand.conf
@@ -25,7 +25,7 @@ PREFERRED_RPROVIDER_u-boot-fw-utils ?= "u-boot-toradex-fw-utils"
 
 # U-Boot NAND binary includes 0x400 padding required for NAND boot
 UBOOT_BINARY = "u-boot-nand.imx"
-UBOOT_MAKE_TARGET = "u-boot-nand.imx"
+UBOOT_MAKE_TARGET = "u-boot.imx"
 UBOOT_MACHINE ?= "colibri_imx7_defconfig"
 
 IMAGE_FSTYPES += "tar.xz"

--- a/recipes-bsp/u-boot/u-boot-toradex_2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-toradex_2019.07.bb
@@ -9,3 +9,17 @@ B = "${WORKDIR}/build"
 do_configure[cleandirs] = "${B}"
 
 inherit fsl-u-boot-localversion
+
+# U-Boot is flashed 1k into a NAND block, create a binary which prepends
+# U-boot with 1k of zeros to ease flashing
+nand_padding () {
+    dd bs=1024 count=1 if=/dev/zero | cat - u-boot.imx > u-boot-nand.imx
+}
+
+do_compile_append_colibri-imx6ull () {
+    nand_padding
+}
+
+do_compile_append_colibri-imx7 () {
+    nand_padding
+}


### PR DESCRIPTION
This fixes build of U-Boot.
The make target u-boot-nand.imx no longer exists u-boot-toradex_2019.07.
Change to the existing build target u-boot.imx and create u-boot-nand.imx in do_configure.