### PR TITLE
Follow u-boot-toradex update

### DIFF
--- a/conf/machine/apalis-imx6.conf
+++ b/conf/machine/apalis-imx6.conf
@@ -32,6 +32,8 @@ UBOOT_ENTRYPOINT_use-mainline-bsp = "0x10008000"
 
 IMAGE_FSTYPES += "tar.xz"
 # wic support
+IMAGE_BOOT_FILES_append = " boot.scr"
+WKS_FILE_DEPENDS_append = " u-boot-script-toradex"
 WKS_FILE = "sdimage-bootpart.wks"
 
 MACHINE_FEATURES += "screen usbgadget usbhost vfat ext2 alsa touchscreen wifi bluetooth 3g pci"

--- a/conf/machine/colibri-imx6.conf
+++ b/conf/machine/colibri-imx6.conf
@@ -31,6 +31,8 @@ UBOOT_ENTRYPOINT_use-mainline-bsp = "0x10008000"
 
 IMAGE_FSTYPES += "tar.xz"
 # wic support
+IMAGE_BOOT_FILES_append = " boot.scr"
+WKS_FILE_DEPENDS_append = " u-boot-script-toradex"
 WKS_FILE = "sdimage-bootpart.wks"
 
 MACHINE_FEATURES += "screen usbgadget usbhost vfat ext2 alsa touchscreen wifi bluetooth 3g"

--- a/conf/machine/colibri-imx6ull.conf
+++ b/conf/machine/colibri-imx6ull.conf
@@ -26,6 +26,8 @@ UBOOT_MACHINE ?= "colibri-imx6ull_defconfig"
 
 IMAGE_FSTYPES += "tar.xz"
 # wic support
+IMAGE_BOOT_FILES_append = " boot.scr"
+WKS_FILE_DEPENDS_append = " u-boot-script-toradex"
 WKS_FILE = "sdimage-bootpart.wks"
 
 MACHINE_FEATURES += "screen usbgadget usbhost vfat ext2 alsa touchscreen wifi bluetooth 3g"

--- a/conf/machine/colibri-imx7-nand.conf
+++ b/conf/machine/colibri-imx7-nand.conf
@@ -30,6 +30,8 @@ UBOOT_MACHINE ?= "colibri_imx7_defconfig"
 
 IMAGE_FSTYPES += "tar.xz"
 # wic support
+IMAGE_BOOT_FILES_append = " boot.scr"
+WKS_FILE_DEPENDS_append = " u-boot-script-toradex"
 WKS_FILE = "sdimage-bootpart.wks"
 
 # Enable free --space-fixup (-F) by default, this allows DFU updates

--- a/conf/machine/colibri-vf.conf
+++ b/conf/machine/colibri-vf.conf
@@ -27,8 +27,8 @@ PREFERRED_PROVIDER_virtual/kernel-module-mcc-dev ?= "kernel-module-mcc-toradex"
 PREFERRED_VERSION_mqxboot ?= "1.%"
 
 # U-Boot NAND binary includes 0x400 padding required for NAND boot
-UBOOT_BINARY ?= "u-boot-nand.imx"
-UBOOT_MAKE_TARGET = "u-boot-nand.imx"
+UBOOT_BINARY = "u-boot-nand.imx"
+UBOOT_MAKE_TARGET = "u-boot.imx"
 UBOOT_MACHINE ?= "colibri_vf_defconfig"
 
 IMAGE_FSTYPES += "tar.xz ubifs"

--- a/conf/machine/colibri-vf.conf
+++ b/conf/machine/colibri-vf.conf
@@ -33,6 +33,8 @@ UBOOT_MACHINE ?= "colibri_vf_defconfig"
 
 IMAGE_FSTYPES += "tar.xz ubifs"
 # wic support
+IMAGE_BOOT_FILES_append = " boot.scr"
+WKS_FILE_DEPENDS_append = " u-boot-script-toradex"
 WKS_FILE = "sdimage-bootpart.wks"
 
 # Enable free --space-fixup (-F) by default, this allows DFU updates

--- a/recipes-bsp/u-boot/u-boot-toradex_2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-toradex_2019.07.bb
@@ -23,3 +23,7 @@ do_compile_append_colibri-imx6ull () {
 do_compile_append_colibri-imx7 () {
     nand_padding
 }
+
+do_compile_append_colibri-vf () {
+    nand_padding
+}


### PR DESCRIPTION
The update from 2016.11 to 2019.07 requires updates in the machine files.
This makes all Toradex machines build again, including colibri-vf.

Tested with colibri-imx6 & colibri-vf with "fslc-x11" and fsl-image-multimedia-full.