### PR TITLE
u-boot-script-toradex: Limit visibility to toradex machines

### DIFF
--- a/recipes-bsp/u-boot/u-boot-script-toradex_2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-script-toradex_2019.07.bb
@@ -41,3 +41,5 @@ addtask deploy after do_install before do_build
 PROVIDES += "virtual/bootscript"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+COMPATIBLE_MACHINE = "(apalis-imx6|colibri-imx6|colibri-imx6ull|colibri-imx7-emmc|colibri-imx7-nand|colibri-vf.conf)"


### PR DESCRIPTION
This helps in making it layer work in multi-bsp environment
Fixes double staging errors like

DEBUG: Staging files from TOPDIR/build/tmp/work/raspberrypi4-yoe-linux-gnueabi/u-boot-script-toradex/2019.07-r0/deploy-u-boot-script-toradex to TOPDIR/build/tmp/deploy/images/raspberrypi4
ERROR: The recipe u-boot-script-toradex is trying to install files into a shared area when those files already exist. Those files and their manifest location are:
  TOPDIR/build/tmp/deploy/images/raspberrypi4/boot.scr
    (matched in manifest-raspberrypi4-rpi-u-boot-scr.deploy)
Please verify which recipe should provide the above files.

Signed-off-by: Khem Raj <raj.khem@gmail.com>
Cc: Max Krummenacher <max.krummenacher@toradex.com>