### PR TITLE
u-boot-script-toradex_2019.07.bb: Fix typo in COMPATIBLE_MACHINE

### DIFF
--- a/recipes-bsp/u-boot/u-boot-script-toradex_2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-script-toradex_2019.07.bb
@@ -42,4 +42,4 @@ PROVIDES += "u-boot-default-script"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-COMPATIBLE_MACHINE = "(apalis-imx6|colibri-imx6|colibri-imx6ull|colibri-imx7-emmc|colibri-imx7-nand|colibri-vf.conf)"
+COMPATIBLE_MACHINE = "(apalis-imx6|colibri-imx6|colibri-imx6ull|colibri-imx7-emmc|colibri-imx7-nand|colibri-vf)"


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>