### PR TITLE
Use new BSP choosing method for mainline based machines

### DIFF
--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -4,10 +4,12 @@
 #@DESCRIPTION: Machine configuration for IMX6QDL-PICO board.
 #@MAINTAINER: Otavio Salvador otavio.salvador@ossystems.com.br
 
-MACHINEOVERRIDES =. "use-mainline-bsp:mx6:mx6dl:mx6q:"
+MACHINEOVERRIDES =. "mx6:mx6dl:mx6q:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa9.inc
+
+IMX_DEFAULT_BSP = "mainline"
 
 SERIAL_CONSOLES = "115200;ttymxc4"
 

--- a/conf/machine/imx6ul-pico.conf
+++ b/conf/machine/imx6ul-pico.conf
@@ -4,10 +4,12 @@
 #@DESCRIPTION: Machine configuration for IMX6UL-PICO board.
 #@MAINTAINER: Daiane Angolini <daiane.angolini@nxp.com>
 
-MACHINEOVERRIDES =. "use-mainline-bsp:mx6:mx6ul:"
+MACHINEOVERRIDES =. "mx6:mx6ul:"
 
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa7.inc
+
+IMX_DEFAULT_BSP = "mainline"
 
 SERIAL_CONSOLES = "115200;ttymxc5"
 

--- a/conf/machine/imx7d-pico.conf
+++ b/conf/machine/imx7d-pico.conf
@@ -4,10 +4,12 @@
 #@DESCRIPTION: Machine configuration for IMX7D-PICO board.
 #@MAINTAINER: Vanessa Maegima <vanessa.maegima@nxp.com>
 
-MACHINEOVERRIDES =. "use-mainline-bsp:mx7:mx7d:"
+MACHINEOVERRIDES =. "mx7:mx7d:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa7.inc
+
+IMX_DEFAULT_BSP = "mainline"
 
 SERIAL_CONSOLES = "115200;ttymxc4"
 

--- a/conf/machine/imx7s-warp.conf
+++ b/conf/machine/imx7s-warp.conf
@@ -4,10 +4,12 @@
 #@DESCRIPTION: Machine configuration for i.MX7S WaRP board.
 #@MAINTAINER: Pierre-Jean Texier <texier.pj2@gmail.com>
 
-MACHINEOVERRIDES =. "mx7:mx7d:use-mainline-bsp:"
+MACHINEOVERRIDES =. "mx7:mx7d:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa7.inc
+
+IMX_DEFAULT_BSP = "mainline"
 
 MACHINE_FEATURES += " wifi bluetooth"
 

--- a/conf/machine/wandboard.conf
+++ b/conf/machine/wandboard.conf
@@ -4,10 +4,12 @@
 #@DESCRIPTION: Machine configuration for i.MX6 Wandboard QuadPlus/Quad/Dual/Solo
 #@MAINTAINER: Alfonso Tames <alfonso@tames.com>
 
-MACHINEOVERRIDES =. "mx6:mx6dl:mx6q:use-mainline-bsp:"
+MACHINEOVERRIDES =. "mx6:mx6dl:mx6q:"
 
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa9.inc
+
+IMX_DEFAULT_BSP = "mainline"
 
 UBOOT_MAKE_TARGET = ""
 UBOOT_SUFFIX = "img"


### PR DESCRIPTION
We now choose the BSP in a generic way and this commit changes the
machines to use the new mechanism setting it to mainline one.

Following changes are changed:

 - imx6qdl-pico
 - imx6ul-pico
 - imx7d-pico
 - imx7s-warp
 - wandboard

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>