### PR TITLE
Temporarily remove bootloader in Nitrogen8M Nano

### DIFF
--- a/conf/machine/nitrogen8mn.conf
+++ b/conf/machine/nitrogen8mn.conf
@@ -21,6 +21,8 @@ KERNEL_IMAGETYPE = "Image"
 KERNEL_DEFCONFIG = "boundary_defconfig"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""
 
+#Temporarily remove bootloader from building, as there are compilation errors.
+WKS_FILE_DEPENDS_mx8_remove = "imx-boot"
 # U-Boot configuration
 PREFERRED_PROVIDER_u-boot ??= "u-boot-boundary"
 PREFERRED_PROVIDER_virtual/bootloader ??= "u-boot-boundary"


### PR DESCRIPTION
There are compilation errors when building bootloader. Temporarily remove and will be fixed at later date.