### PR TITLE
nitrogen8*: Include tune-cortexa53.inc instead of generic arch-arm64.inc

### DIFF
--- a/conf/machine/nitrogen8m.conf
+++ b/conf/machine/nitrogen8m.conf
@@ -7,7 +7,7 @@
 MACHINEOVERRIDES =. "mx8:mx8m:mx8mq:"
 
 require conf/machine/include/imx-base.inc
-require conf/machine/include/arm/arch-arm64.inc
+require conf/machine/include/tune-cortexa53.inc
 
 # Kernel configuration
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-boundary"

--- a/conf/machine/nitrogen8mm.conf
+++ b/conf/machine/nitrogen8mm.conf
@@ -7,7 +7,7 @@
 MACHINEOVERRIDES =. "mx8:mx8mm:"  
 
 require conf/machine/include/imx-base.inc
-require conf/machine/include/arm/arch-arm64.inc
+require conf/machine/include/tune-cortexa53.inc
 
 # Kernel configuration
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-boundary"

--- a/conf/machine/nitrogen8mn.conf
+++ b/conf/machine/nitrogen8mn.conf
@@ -7,7 +7,7 @@
 MACHINEOVERRIDES =. "mx8:mx8mn:"
 
 require conf/machine/include/imx-base.inc
-require conf/machine/include/arm/arch-arm64.inc
+require conf/machine/include/tune-cortexa53.inc
 
 # Kernel configuration
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-boundary"


### PR DESCRIPTION
This fixes the following build error:

> Error, the PACKAGE_ARCHS variable (all any noarch ${PACKAGE_EXTRA_ARCHS_tune-cortexa53-crypto} nitrogen8m) for DEFAULTTUNE (cortexa53-crypto) does not contain TUNE_PKGARCH (${@bb.utils.contains('TUNE_FEATURES', 'aarch64', 'aarch64', '${ARMPKGARCH_tune-cortexa53-crypto}' ,d)}).Toolchain tunings invalid:
> Tuning 'cortexa53-crypto' has no defined features, and cannot be used.

Signed-off-by: Carlos Rafael Giani <crg7475@mailbox.org>