### PR TITLE
colibri-imx7: Fix mainline and NXP BXP support

### DIFF
--- a/conf/machine/colibri-imx7-emmc.conf
+++ b/conf/machine/colibri-imx7-emmc.conf
@@ -9,8 +9,10 @@ MACHINEOVERRIDES =. "mx7:mx7d:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa7.inc
 
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-toradex"
-KERNEL_DEVICETREE += "imx7d-colibri-emmc-eval-v3.dtb imx7d-colibri-emmc-aster.dtb"
+PREFERRED_PROVIDER_virtual/kernel_use-nxp-bsp ??= "linux-toradex"
+
+KERNEL_DEVICETREE = "imx7d-colibri-emmc-eval-v3.dtb"
+KERNEL_DEVICETREE_append_use-nxp-bsp = " imx7d-colibri-emmc-aster.dtb"
 
 # The kernel lives in a seperate FAT partition, don't deploy it in /boot/
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""

--- a/conf/machine/colibri-imx7-nand.conf
+++ b/conf/machine/colibri-imx7-nand.conf
@@ -9,10 +9,19 @@ MACHINEOVERRIDES =. "mx7:mx7d:colibri-imx7:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa7.inc
 
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-toradex"
+PREFERRED_PROVIDER_virtual/kernel_use-nxp-bsp ??= "linux-toradex"
+
 KERNEL_IMAGETYPE = "zImage"
-KERNEL_DEVICETREE += "imx7d-colibri-eval-v3.dtb imx7s-colibri-eval-v3.dtb \
-                      imx7d-colibri-aster.dtb imx7s-colibri-aster.dtb"
+
+KERNEL_DEVICETREE = " \
+    imx7d-colibri-eval-v3.dtb \
+    imx7s-colibri-eval-v3.dtb \
+"
+
+KERNEL_DEVICETREE_append_use-nxp-bsp = " \
+    imx7d-colibri-aster.dtb \
+    imx7s-colibri-aster.dtb \
+"
 
 # U-Boot of our newer release read the Kernel and device tree from static UBI
 # volumes, hence no need to deploy the kernel binary in the image itself

--- a/conf/machine/colibri-vf.conf
+++ b/conf/machine/colibri-vf.conf
@@ -9,10 +9,19 @@ MACHINEOVERRIDES =. "vf:vf50:vf60:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa5.inc
 
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-toradex"
+PREFERRED_PROVIDER_virtual/kernel_use-nxp-bsp ??= "linux-toradex"
+
 KERNEL_IMAGETYPE = "zImage"
-KERNEL_DEVICETREE += "vf500-colibri-eval-v3.dtb vf610-colibri-eval-v3.dtb \
-                      vf500-colibri-aster.dtb vf610-colibri-aster.dtb"
+
+KERNEL_DEVICETREE = " \
+    vf500-colibri-eval-v3.dtb \
+    vf610-colibri-eval-v3.dtb \
+"
+
+KERNEL_DEVICETREE_append_use-nxp-bsp = " \
+    vf500-colibri-aster.dtb \
+    vf610-colibri-aster.dtb \
+"
 
 # U-Boot of our newer release read the Kernel and device tree from static UBI volumes,
 # hence no need to deploy the kernel binary in the image itself

--- a/recipes-kernel/linux/linux-toradex_4.4.bb
+++ b/recipes-kernel/linux/linux-toradex_4.4.bb
@@ -11,6 +11,8 @@ KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains('COMBINED_FEATURES', 'usbgadget'
 LOCALVERSION = "-2.8.3"
 PV_append = "+git${SRCPV}"
 
+LINUX_VERSION = "4.4.217"
+
 SRCBRANCH = "toradex_vf_4.4"
 SRCREV = "4a31b8a3519d5dde0eacbb088b0d45c83732535b"
 


### PR DESCRIPTION
We need to support both mainline and NXP BSP support, to allow that we
need:

 - split generic and NXP BSP specific device trees
 - avoid setting the default Linux kernel if we use mainline BSP

This was applied for:

 - colibri-imx7-emmc
 - colibri-imx7-nand

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>