### PR TITLE
colibri-vf: set preferred version for weston

### DIFF
--- a/conf/machine/colibri-vf.conf
+++ b/conf/machine/colibri-vf.conf
@@ -35,6 +35,7 @@ PREFERRED_PROVIDER_u-boot-default-script ?= "u-boot-script-toradex"
 PREFERRED_PROVIDER_virtual/kernel-module-mcc ?= "kernel-module-mcc-toradex"
 PREFERRED_PROVIDER_virtual/kernel-module-mcc-dev ?= "kernel-module-mcc-toradex"
 PREFERRED_VERSION_mqxboot ?= "1.%"
+PREFERRED_VERSION_weston_use-nxp-bsp = ""
 
 # U-Boot NAND binary includes 0x400 padding required for NAND boot
 UBOOT_BINARY = "u-boot-nand.imx"


### PR DESCRIPTION
The imx specific weston version which is otherwise set is not in
COMPATIBLE_MACHINE for Vybrids.
Prevents:
| NOTE: preferred version 8.0.0.imx of weston not available (for item weston)
| NOTE: versions of weston available: 8.0.0

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>