### PR TITLE
u-boot-kontron: Bump revision to 3d58441adf3

### DIFF
--- a/recipes-bsp/u-boot/u-boot-kontron_2020.01.bb
+++ b/recipes-bsp/u-boot/u-boot-kontron_2020.01.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 SRC_URI = "git://git.kontron-electronics.de/linux/u-boot.git;protocol=https;branch=${SRCBRANCH} \
            file://fw_env.config \
 "
-SRCREV = "1fd382a2ae23d917a3949b4dd899ecfbaa158843"
+SRCREV = "3d58441adf3e633279db6c96acb33a7aef4fd6f9"
 SRCBRANCH = "v2020.01-ktn"
 LOCALVERSION = "-ktn"
 


### PR DESCRIPTION
This commit includes the following changes:

    - 3d58441adf3 kontron_mx6ul: Use the SPI NOR as primary boot device to load U-Boot proper
    - f1db3d8504b kontron_mx6ul: Use 64K offset for U-Boot proper image, in SPI NOR
    - e1d78d738c6 kontron_mx6ul: Fix support for SPI NOR boot
    - c5e0df84780 kontron_mx6ul: Enable SPI NAND support

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>