### PR TITLE
u-boot-variscite build fixes

### DIFF
--- a/recipes-bsp/u-boot/u-boot-variscite_2017.03.bb
+++ b/recipes-bsp/u-boot/u-boot-variscite_2017.03.bb
@@ -5,6 +5,8 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
 COMPATIBLE_MACHINE = "(imx6qdl-variscite-som)"
 
+DEPENDS += "bc-native"
+
 PROVIDES += "u-boot"
 
 SPL_BINARY = "SPL"

--- a/recipes-bsp/u-boot/u-boot-variscite_2017.03.bb
+++ b/recipes-bsp/u-boot/u-boot-variscite_2017.03.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
 COMPATIBLE_MACHINE = "(imx6qdl-variscite-som)"
 
 DEPENDS += "bc-native"
+UBOOT_INITIAL_ENV = ""
 
 PROVIDES += "u-boot"
 


### PR DESCRIPTION
Yes it's time to upgrade u-boot-variscite but:

* am very busy keeping things working and a new version requires resources unavailable currently
* once [1] gets applied to oe-core's dunfell, we can backport this series to dunfell

[1] https://lists.openembedded.org/g/openembedded-core/message/139646