### PR TITLE
linux-boundary: add 5.4.50 recipe

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.4.bb
+++ b/recipes-kernel/linux/linux-boundary_5.4.bb
@@ -5,14 +5,17 @@ require recipes-kernel/linux/linux-imx.inc
 
 SUMMARY = "Linux kernel for Boundary Devices boards"
 
-LINUX_VERSION = "4.14.98"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+LINUX_VERSION = "5.4.50"
 
 SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH} \
 "
 
-LOCALVERSION = "-2.0.0-ga+yocto"
-SRCBRANCH = "boundary-imx_4.14.x_2.0.0_ga"
-SRCREV = "a43570ced29f21cfbd5eff12b843f9214271aaf3"
+LOCALVERSION = "-2.1.0-ga+yocto"
+SRCBRANCH = "boundary-imx_5.4.x_2.1.0"
+SRCREV = "503a3dce966a6b98e7bfdc376477c604a4275c60"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn)"
 


### PR DESCRIPTION
Based on NXP imx_5.4.24_2.1.0 release.
Includes latest stable releases, hence 5.4.x naming.
Includes support for all Boundary Devices platforms + accessories.