### PR TITLE
u-boot-boundary: Bump revision to eae0188

### DIFF
--- a/recipes-bsp/u-boot/u-boot-boundary-common_2018.07.inc
+++ b/recipes-bsp/u-boot/u-boot-boundary-common_2018.07.inc
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 
 PV = "v2018.07+git${SRCPV}"
 
-SRCREV = "17fe0ef3aff3abc3908c854bfab1c283ed84d9c0"
+SRCREV = "eae0188ff8e835fcb2351324af88998f0e4213db"
 SRCBRANCH = "boundary-v2018.07"
 SRC_URI = "git://github.com/boundarydevices/u-boot-imx6.git;branch=${SRCBRANCH}"
 


### PR DESCRIPTION
LPDDR4 init updates
Android security features enabled
Fixed env import
Enabled HAB for i.MX 8M family
Fixed Nano board support
Fixed build with GCC10
Fixed i.MX 8M Mini ARM PLL choice