### PR TITLE
cubox-i.conf: Fix root partition

### DIFF
--- a/conf/machine/cubox-i.conf
+++ b/conf/machine/cubox-i.conf
@@ -26,7 +26,7 @@ SPL_BINARY = "SPL"
 WKS_FILES = "imx-uboot-spl.wks.in"
 
 UBOOT_EXTLINUX = "1"
-UBOOT_EXTLINUX_ROOT = "root=PARTUUID=${uuid}"
+UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk1p1"
 
 KERNEL_IMAGETYPE = "zImage"
 KERNEL_DEVICETREE = "imx6dl-cubox-i.dtb imx6q-cubox-i.dtb imx6dl-hummingboard.dtb imx6q-hummingboard.dtb"


### PR DESCRIPTION
Set UBOOT_EXTLINUX_ROOT to /dev/mmcblk1p1 to avoid kernel panic
and issues with the rootfs for cubox-i:

VFS: Unable to mount root fs on unknown-block

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>