### PR TITLE
alsa-state.bbappend: Fix asound.conf for cubox-i

### DIFF
--- a/recipes-bsp/alsa-state/alsa-state.bbappend
+++ b/recipes-bsp/alsa-state/alsa-state.bbappend
@@ -1,0 +1,4 @@
+do_install_append_cubox-i() {
+	sed -i -e 's/0,0/2,0/g' ${D}${sysconfdir}/asound.conf
+	sed -i -e 's/card 0/card 2/g' ${D}${sysconfdir}/asound.conf
+}


### PR DESCRIPTION
Fix /etc/asound.conf and enable sound out of the box with the
default machine configurations for cubox-i and hummingboard.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>