### PR TITLE
alsa-state.bbappend: Fix asound.conf for cubox-i

### DIFF
--- a/recipes-bsp/alsa-state/alsa-state.bbappend
+++ b/recipes-bsp/alsa-state/alsa-state.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend_cubox-i := "${THISDIR}/files:"

--- a/recipes-bsp/alsa-state/files/cubox-i/asound.conf
+++ b/recipes-bsp/alsa-state/files/cubox-i/asound.conf
@@ -1,0 +1,459 @@
+defaults.pcm.rate_converter "linear"
+
+pcm.dmix_48000{
+type dmix
+ipc_key 5678293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 48000
+}
+}
+
+pcm.dmix_44100{
+type dmix
+ipc_key 5678293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 44100
+}
+}
+
+pcm.dmix_32000{
+type dmix
+ipc_key 5678293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 32000
+}
+}
+
+pcm.dmix_24000{
+type dmix
+ipc_key 5678293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 24000
+}
+}
+
+pcm.dmix_22050{
+type dmix
+ipc_key 5678293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 22050
+}
+}
+
+pcm.dmix_16000{
+type dmix
+ipc_key 5678293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 16000
+}
+}
+
+pcm.dmix_12000{
+type dmix
+ipc_key 5678293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 12000
+}
+}
+
+pcm.dmix_11025{
+type dmix
+ipc_key 5678293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 11025
+}
+}
+
+pcm.dmix_8000{
+type dmix
+ipc_key 5678293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 8000
+}
+}
+
+pcm.!dsnoop_48000{
+type dsnoop
+ipc_key 5778293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 48000
+}
+}
+
+pcm.!dsnoop_44100{
+type dsnoop
+ipc_key 5778293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 44100
+}
+}
+
+pcm.!dsnoop_32000{
+type dsnoop
+ipc_key 5778293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 32000
+}
+}
+
+pcm.!dsnoop_24000{
+type dsnoop
+ipc_key 5778293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 24000
+}
+}
+
+pcm.!dsnoop_22050{
+type dsnoop
+ipc_key 5778293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 22050
+}
+}
+
+pcm.!dsnoop_16000{
+type dsnoop
+ipc_key 5778293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 16000
+}
+}
+
+pcm.!dsnoop_12000{
+type dsnoop
+ipc_key 5778293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 12000
+}
+}
+
+pcm.!dsnoop_11025{
+type dsnoop
+ipc_key 5778293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 11025
+}
+}
+
+pcm.!dsnoop_8000{
+type dsnoop
+ipc_key 5778293
+ipc_key_add_uid yes
+slave{
+pcm "hw:2,0"
+period_time 40000
+format S16_LE
+rate 8000
+}
+}
+
+pcm.asymed{
+type asym
+playback.pcm "dmix_44100"
+capture.pcm "dsnoop_44100"
+}
+
+pcm.dsp0{
+type plug
+slave.pcm "asymed"
+}
+
+pcm.!default{
+type plug
+route_policy "average"
+slave.pcm "asymed"
+}
+
+ctl.!default{
+type hw
+card 2
+}
+
+ctl.mixer0{
+type hw
+card 2
+}
+
+pcm_slave.esai{
+	pcm "hw:2,0"
+	channels 8
+	rate 48000
+	period_time 40000
+}
+
+pcm.esaich1to6{
+	type dshare
+	ipc_key 5778293
+	slave esai
+	bindings.0 0
+	bindings.1 4
+	bindings.2 1
+	bindings.3 5
+	bindings.4 2
+	bindings.5 6
+}
+
+pcm.esaich78{
+	type dshare
+	ipc_key 5778293
+	slave esai
+	bindings.0 3
+	bindings.1 7
+}
+
+pcm_slave.sai5 {
+	pcm "hw:5,0"
+	channels 8
+}
+
+pcm.sai5_ch1to8 {
+	type dsnoop
+	ipc_key 5185558
+	slave sai5
+	bindings.0 0
+	bindings.1 4
+	bindings.2 1
+	bindings.3 5
+	bindings.4 2
+	bindings.5 6
+	bindings.6 3
+	bindings.7 7
+}
+
+pcm.sai5_ch1to6 {
+	type dsnoop
+	ipc_key 5165558
+	slave sai5
+	bindings.0 0
+	bindings.1 4
+	bindings.2 1
+	bindings.3 5
+	bindings.4 2
+	bindings.5 6
+}
+
+pcm.sai5_ch1to4 {
+	type dsnoop
+	ipc_key 5145558
+	slave sai5
+	bindings.0 0
+	bindings.1 4
+	bindings.2 1
+	bindings.3 5
+}
+
+pcm_slave.sai1{
+	pcm "hw:4,0"
+	channels 16
+}
+
+pcm.sai1to16{
+	type dshare
+	slave sai1
+	ipc_key 5144458
+	bindings.0 0
+	bindings.1 8
+	bindings.2 1
+	bindings.3 9
+	bindings.4 2
+	bindings.5 10
+	bindings.6 3
+	bindings.7 11
+	bindings.8 4
+	bindings.9 12
+	bindings.10 5
+	bindings.11 13
+	bindings.12 6
+	bindings.13 14
+	bindings.14 7
+	bindings.15 15
+}
+
+pcm.sai1to14{
+	type dshare
+	slave sai1
+	ipc_key 5144458
+	bindings.0 0
+	bindings.1 8
+	bindings.2 1
+	bindings.3 9
+	bindings.4 2
+	bindings.5 10
+	bindings.6 3
+	bindings.7 11
+	bindings.8 4
+	bindings.9 12
+	bindings.10 5
+	bindings.11 13
+	bindings.12 6
+	bindings.13 14
+}
+
+pcm.sai1to12{
+	type dshare
+	slave sai1
+	ipc_key 5144458
+	bindings.0 0
+	bindings.1 8
+	bindings.2 1
+	bindings.3 9
+	bindings.4 2
+	bindings.5 10
+	bindings.6 3
+	bindings.7 11
+	bindings.8 4
+	bindings.9 12
+	bindings.10 5
+	bindings.11 13
+}
+
+pcm.sai1to10{
+	type dshare
+	slave sai1
+	ipc_key 5144458
+	bindings.0 0
+	bindings.1 8
+	bindings.2 1
+	bindings.3 9
+	bindings.4 2
+	bindings.5 10
+	bindings.6 3
+	bindings.7 11
+	bindings.8 4
+	bindings.9 12
+}
+
+pcm.sai1to8{
+	type dshare
+	slave sai1
+	ipc_key 5144458
+	bindings.0 0
+	bindings.1 8
+	bindings.2 1
+	bindings.3 9
+	bindings.4 2
+	bindings.5 10
+	bindings.6 3
+	bindings.7 11
+}
+
+pcm.sai1to6{
+	type dshare
+	slave sai1
+	ipc_key 5144458
+	bindings.0 0
+	bindings.1 8
+	bindings.2 1
+	bindings.3 9
+	bindings.4 2
+	bindings.5 10
+}
+
+pcm.sai1to4{
+	type dshare
+	slave sai1
+	ipc_key 5144458
+	bindings.0 0
+	bindings.1 8
+	bindings.2 1
+	bindings.3 9
+}
+
+pcm.cdnhdmi4ch {
+	type dshare
+	slave {
+		pcm "hw:3,0"
+		channels 4
+	}
+	ipc_key 5144458
+	bindings.0 0
+	bindings.1 2
+	bindings.2 1
+	bindings.3 3
+}
+
+pcm.cdnhdmi8ch {
+	type dshare
+	slave {
+		pcm "hw:3,0"
+		channels 8
+	}
+	ipc_key 5144458
+	bindings.0 0
+	bindings.1 4
+	bindings.2 1
+	bindings.3 5
+	bindings.4 2
+	bindings.5 6
+	bindings.6 3
+	bindings.7 7
+}


### PR DESCRIPTION
Fix /etc/asound.conf and enable sound out of the box with the
default machine configurations for cubox-i and hummingboard.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>