### PR TITLE
u-boot-boundary: do not install mkimage_uboot any longer

### DIFF
--- a/recipes-bsp/u-boot/u-boot-boundary_2018.07.bb
+++ b/recipes-bsp/u-boot/u-boot-boundary_2018.07.bb
@@ -16,7 +16,6 @@ BOOT_TOOLS = "imx-boot-tools"
 do_deploy_append_mx8 () {
 	install -d ${DEPLOYDIR}/${BOOT_TOOLS}
 	install -m 0777 ${B}/${config}/arch/arm/dts/${UBOOT_DTB_NAME}  ${DEPLOYDIR}/${BOOT_TOOLS}
-	install -m 0777 ${B}/${config}/tools/mkimage  ${DEPLOYDIR}/${BOOT_TOOLS}/mkimage_uboot
 	install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG}
 }
 


### PR DESCRIPTION
As this now conflicts with imx-boot which already does it.

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>