### PR TITLE
Allow override IMX_DEFAULT_BSP for Nitrogen machines

### DIFF
--- a/conf/machine/nitrogen6sx.conf
+++ b/conf/machine/nitrogen6sx.conf
@@ -6,10 +6,10 @@
 
 MACHINEOVERRIDES =. "mx6:mx6sx:"
 
+IMX_DEFAULT_BSP ?= "nxp"
+
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa9.inc
-
-IMX_DEFAULT_BSP = "nxp"
 
 KERNEL_DEVICETREE = "imx6sx-nitrogen6sx.dtb"
 KERNEL_IMAGETYPE = "zImage"

--- a/conf/machine/nitrogen6x-lite.conf
+++ b/conf/machine/nitrogen6x-lite.conf
@@ -6,10 +6,10 @@
 
 MACHINEOVERRIDES =. "mx6:mx6dl:"
 
+IMX_DEFAULT_BSP ?= "nxp"
+
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa9.inc
-
-IMX_DEFAULT_BSP = "nxp"
 
 KERNEL_DEVICETREE = "imx6dl-nit6xlite.dtb"
 KERNEL_IMAGETYPE = "zImage"

--- a/conf/machine/nitrogen6x.conf
+++ b/conf/machine/nitrogen6x.conf
@@ -31,10 +31,10 @@
 
 MACHINEOVERRIDES =. "mx6:mx6dl:mx6q:"
 
+IMX_DEFAULT_BSP ?= "nxp"
+
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa9.inc
-
-IMX_DEFAULT_BSP = "nxp"
 
 KERNEL_DEVICETREE = "imx6q-sabrelite.dtb \
                         imx6q-nitrogen6_max.dtb imx6qp-nitrogen6_max.dtb \

--- a/conf/machine/nitrogen7.conf
+++ b/conf/machine/nitrogen7.conf
@@ -6,10 +6,10 @@
 
 MACHINEOVERRIDES =. "mx7:mx7d:"
 
+IMX_DEFAULT_BSP ?= "nxp"
+
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa7.inc
-
-IMX_DEFAULT_BSP = "nxp"
 
 KERNEL_DEVICETREE = "imx7d-nitrogen7.dtb"
 KERNEL_IMAGETYPE = "zImage"

--- a/conf/machine/nitrogen8m.conf
+++ b/conf/machine/nitrogen8m.conf
@@ -6,10 +6,10 @@
 
 MACHINEOVERRIDES =. "mx8:mx8m:mx8mq:"
 
+IMX_DEFAULT_BSP ?= "nxp"
+
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa53.inc
-
-IMX_DEFAULT_BSP = "nxp"
 
 # Kernel configuration
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-boundary"

--- a/conf/machine/nitrogen8mm.conf
+++ b/conf/machine/nitrogen8mm.conf
@@ -6,10 +6,10 @@
 
 MACHINEOVERRIDES =. "mx8:mx8m:mx8mm:"
 
+IMX_DEFAULT_BSP ?= "nxp"
+
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa53.inc
-
-IMX_DEFAULT_BSP = "nxp"
 
 # Kernel configuration
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-boundary"

--- a/conf/machine/nitrogen8mn.conf
+++ b/conf/machine/nitrogen8mn.conf
@@ -6,10 +6,10 @@
 
 MACHINEOVERRIDES =. "mx8:mx8m:mx8mn:"
 
+IMX_DEFAULT_BSP ?= "nxp"
+
 require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa53.inc
-
-IMX_DEFAULT_BSP = "nxp"
 
 # Kernel configuration
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-boundary"


### PR DESCRIPTION
Set a weak assignment for IMX_DEFAULT_BSP before include the
imx-base.inc to allow override IMX_DEFAULT_BSP in local.conf file.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>