### PR TITLE
[zeus] update 4.14 kernel and 2018.07 uboot

### DIFF
--- a/recipes-bsp/u-boot/u-boot-boundary-common_2018.07.inc
+++ b/recipes-bsp/u-boot/u-boot-boundary-common_2018.07.inc
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 
 PV = "v2018.07+git${SRCPV}"
 
-SRCREV = "17fe0ef3aff3abc3908c854bfab1c283ed84d9c0"
+SRCREV = "b75d1f64ef30120fbdfbf37f82af237422f4fabd"
 SRCBRANCH = "boundary-v2018.07"
 SRC_URI = "git://github.com/boundarydevices/u-boot-imx6.git;branch=${SRCBRANCH}"
 

--- a/recipes-kernel/linux/linux-boundary_4.14.x.bb
+++ b/recipes-kernel/linux/linux-boundary_4.14.x.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH} \
 
 LOCALVERSION = "-2.0.0-ga+yocto"
 SRCBRANCH = "boundary-imx_4.14.x_2.0.0_ga"
-SRCREV = "a43570ced29f21cfbd5eff12b843f9214271aaf3"
+SRCREV = "e4741cb9763742efc65913e68bd32d926978c822"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn)"
 


### PR DESCRIPTION
Some customers are still on zeus and would like to get the latest rev of kernel/uboot.