### PR TITLE
imx-pico: Always use the NXP bootloader when using the NXP BSP

### DIFF
--- a/conf/machine/cubox-i.conf
+++ b/conf/machine/cubox-i.conf
@@ -36,8 +36,6 @@ MACHINE_EXTRA_RRECOMMENDS += "bcm4330-nvram-config bcm4329-nvram-config"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
-    kernel-image \
-    kernel-devicetree \
-    u-boot-fslc \
-"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-mainline-bsp += "u-boot-fslc"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-nxp-bsp += "u-boot-imx"

--- a/conf/machine/imx6dl-riotboard.conf
+++ b/conf/machine/imx6dl-riotboard.conf
@@ -16,10 +16,8 @@ KERNEL_DEVICETREE = "imx6dl-riotboard.dtb"
 
 SERIAL_CONSOLES = "115200;ttymxc1"
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
-    kernel-image \
-    kernel-devicetree \
-    u-boot-fslc \
-"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-mainline-bsp += "u-boot-fslc"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-nxp-bsp += "u-boot-imx"
 
 WKS_FILES = "imx-uboot.wks"

--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -35,11 +35,9 @@ KERNEL_DEVICETREE = " \
     imx6q-pico-pi.dtb \
 "
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
-    kernel-image \
-    kernel-devicetree \
-    u-boot-fslc \
-"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-mainline-bsp += "u-boot-fslc"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-nxp-bsp += "u-boot-imx"
 
 MACHINE_EXTRA_RRECOMMENDS += " \
     bcm4339-nvram-config \

--- a/conf/machine/imx6ul-pico.conf
+++ b/conf/machine/imx6ul-pico.conf
@@ -33,11 +33,9 @@ UBOOT_EXTLINUX = "1"
 UBOOT_EXTLINUX_ROOT = "root=PARTUUID=${uuid}"
 UBOOT_EXTLINUX_CONSOLE = "console=${console},${baudrate}"
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
-    kernel-image \
-    kernel-devicetree \
-    u-boot-fslc \
-"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-mainline-bsp += "u-boot-fslc"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-nxp-bsp += "u-boot-imx"
 
 MACHINE_FEATURES += "wifi bluetooth"
 

--- a/conf/machine/imx7d-pico.conf
+++ b/conf/machine/imx7d-pico.conf
@@ -34,11 +34,9 @@ UBOOT_EXTLINUX = "1"
 UBOOT_EXTLINUX_ROOT = "root=PARTUUID=${uuid}"
 UBOOT_EXTLINUX_CONSOLE = "console=${console},${baudrate}"
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
-    kernel-image \
-    kernel-devicetree \
-    u-boot-fslc \
-"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-mainline-bsp += "u-boot-fslc"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-nxp-bsp += "u-boot-imx"
 
 MACHINE_EXTRA_RRECOMMENDS += " \
   bcm4339-nvram-config \

--- a/conf/machine/wandboard.conf
+++ b/conf/machine/wandboard.conf
@@ -44,10 +44,8 @@ MACHINE_EXTRA_RRECOMMENDS += " \
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
-    kernel-image \
-    kernel-devicetree \
-    u-boot-fslc \
-"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-mainline-bsp += "u-boot-fslc"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_use-nxp-bsp += "u-boot-imx"
 
 WKS_FILES = "imx-uboot-spl.wks.in"


### PR DESCRIPTION
The NXP BSP should always use u-boot-imx. This should make NXP distros buildable on PICO boards. 
Related pull-request: Freescale/meta-freescale#626.