### PR TITLE
linux-boundary: update to version 5.4.90

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.4.bb
+++ b/recipes-kernel/linux/linux-boundary_5.4.bb
@@ -8,14 +8,14 @@ SUMMARY = "Linux kernel for Boundary Devices boards"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-LINUX_VERSION = "5.4.80"
+LINUX_VERSION = "5.4.90"
 
 SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH} \
 "
 
 LOCALVERSION = "-2.2.0+yocto"
 SRCBRANCH = "boundary-imx_5.4.x_2.2.0"
-SRCREV = "521466cb0f2cf0e51ed4f509ee633143ab62bf46"
+SRCREV = "9d03cf446eaa2bee63af0d346802fb3f6ecd8e92"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn)"
 


### PR DESCRIPTION
Update to linux version 5.4.90.

Signed-off-by: Chris Dimich <Chris.Dimich@boundarydevices.com>