### PR TITLE
README: update link of mailing list

### DIFF
--- a/README
+++ b/README
@@ -31,7 +31,7 @@ follow-up discussions please use GitHub's notification system.
 
 Mailing list:
 
-    https://lists.yoctoproject.org/listinfo/meta-freescale
+    https://lists.yoctoproject.org/g/meta-freescale
 
 Source code:
 


### PR DESCRIPTION
Old link is not accessible anymore and return 404.

Update README to point to correct mailing list URL.

Fixes: #107 ("Mailing list link in README is a dead link")
Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>