### PR TITLE
imx-pico: Pico only supports the u-boot-fslc bootloader 

### DIFF
--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -10,6 +10,7 @@ require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa9.inc
 
 IMX_DEFAULT_BSP = "mainline"
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
 
 SERIAL_CONSOLES = "115200;ttymxc4"
 

--- a/conf/machine/imx6ul-pico.conf
+++ b/conf/machine/imx6ul-pico.conf
@@ -10,6 +10,7 @@ include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-cortexa7.inc
 
 IMX_DEFAULT_BSP = "mainline"
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
 
 SERIAL_CONSOLES = "115200;ttymxc5"
 

--- a/conf/machine/imx7d-pico.conf
+++ b/conf/machine/imx7d-pico.conf
@@ -10,6 +10,7 @@ require conf/machine/include/imx-base.inc
 require conf/machine/include/tune-cortexa7.inc
 
 IMX_DEFAULT_BSP = "mainline"
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
 
 SERIAL_CONSOLES = "115200;ttymxc4"
 


### PR DESCRIPTION
We must force the bootloader to `u-boot-fslc` if this was set by a distro. 