### PR TITLE
olinuxino: update U-Boot choosing

### DIFF
--- a/conf/machine/include/imx233-olinuxino.inc
+++ b/conf/machine/include/imx233-olinuxino.inc
@@ -6,6 +6,13 @@ MACHINEOVERRIDES =. "mxs:mx23:imx233-olinuxino:"
 include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-arm926ejs.inc
 
+# This machine is not supported by u-boot-imx as it is not tested by NXP on this
+# board. So we force it to use u-boot-fslc which is based on mainline here.
+IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+
+UBOOT_MAKE_TARGET = "u-boot.sb"
+UBOOT_SUFFIX = "sb"
+
 IMXBOOTLETS_MACHINE = "stmp378x_dev"
 UBOOT_MACHINE = "mx23_olinuxino_config"
 


### PR DESCRIPTION
A change was made to meta-freescale to change how the bootloader was being
selected:
	https://github.com/Freescale/meta-freescale/pull/696

As a result the choosing logic for the olinuxino MACHINEs was updated to
match.

Build tested for:
	- imx233-olinuxino-maxi
	- imx233-olinuxino-micro
	- imx233-olinuxino-mini
	- imx233-olinuxino-nano
Run tested on:
	- imx233-olinuxino-maxi

Signed-off-by: Trevor Woerner <twoerner@gmail.com>