### PR TITLE
olinuxino: U-Boot fixup

### DIFF
--- a/conf/machine/include/imx233-olinuxino.inc
+++ b/conf/machine/include/imx233-olinuxino.inc
@@ -7,8 +7,8 @@ include conf/machine/include/imx-base.inc
 include conf/machine/include/tune-arm926ejs.inc
 
 # This machine is not supported by u-boot-imx as it is not tested by NXP on this
-# board. So we force it to use u-boot-fslc which is based on mainline here.
-IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
+# board. Use mainline instead.
+IMX_DEFAULT_BOOTLOADER = "u-boot"
 
 UBOOT_MAKE_TARGET = "u-boot.sb"
 UBOOT_SUFFIX = "sb"


### PR DESCRIPTION
A change was made in oe-core, that forced a change in the BSP layer, that
highlighted an issue with the U-Boot variable for the olinuxino machines.

Build tested for:
    - imx233-olinuxino-maxi
    - imx233-olinuxino-micro
    - imx233-olinuxino-mini
    - imx233-olinuxino-nano
Run tested on:
    - imx233-olinuxino-maxi

Signed-off-by: Trevor Woerner <twoerner@gmail.com>