### PR TITLE
Backport to gatesgarth: linux-boundary: bump revision to e5cde7b

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.4.bb
+++ b/recipes-kernel/linux/linux-boundary_5.4.bb
@@ -8,14 +8,14 @@ SUMMARY = "Linux kernel for Boundary Devices boards"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-LINUX_VERSION = "5.4.100"
+LINUX_VERSION = "5.4.110"
 
 SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH} \
 "
 
 LOCALVERSION = "-2.3.0+yocto"
 SRCBRANCH = "boundary-imx_5.4.x_2.3.0"
-SRCREV = "0258901967596319648aa7d36b3ac689bd75e067"
+SRCREV = "e5cde7b05e548bebb7cc21113505538b98c0984e"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
Update to linux version 5.4.110.