### PR TITLE
imx6qdl-pico: Fix the serial console port

### DIFF
--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -12,7 +12,7 @@ require conf/machine/include/tune-cortexa9.inc
 IMX_DEFAULT_BSP = "mainline"
 IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
 
-SERIAL_CONSOLES = "115200;ttymxc4"
+SERIAL_CONSOLES = "115200;ttymxc0"
 
 SPL_BINARY = "SPL"
 UBOOT_SUFFIX = "img"


### PR DESCRIPTION
On the imx6qdl-pico boards the console is provided by the
UART1 pins, so change it to ttymxc0.

Signed-off-by: Fabio Estevam <festevam@gmail.com>