### PR TITLE
imx6qdl-pico: Add QCA9377 Wifi support

### DIFF
--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -35,6 +35,7 @@ KERNEL_DEVICETREE = " \
     imx6q-pico-nymph.dtb \
     imx6q-pico-pi.dtb \
 "
+MACHINE_FEATURES += "bluetooth wifi"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
     kernel-image \
@@ -49,3 +50,7 @@ MACHINE_EXTRA_RRECOMMENDS += " \
 WKS_FILES ?= "imx-uboot-spl.wks.in"
 WKS_FILE_DEPENDS ?= ""
 IMAGE_FSTYPES = "wic.bmap wic.xz ext4.gz"
+
+MACHINE_FIRMWARE_append = " linux-firmware-ath10k"
+
+MACHINE_FEATURES += " pci bluetooth touchscreen wifi"


### PR DESCRIPTION
Add QCA9377 Wifi support.

Tested on a imx6dl-pico-pi board by doing:

ifconfig wlan0 up
iw dev wlan0 connect ACCESSPOINTNAME
wpa_passphrase ACCESSPOINTNAME > /etc/wpa.conf
(enter the wifi password and press enter)
wpa_supplicant -Dwext -iwlan0 -c /etc/wpa.conf &
udhcpc -i wlan0
ping google.com

Signed-off-by: Fabio Estevam <festevam@gmail.com>