### PR TITLE
imx6qdl-pico: Remove duplicate MACHINE_FEATURES entry

### DIFF
--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -35,8 +35,6 @@ KERNEL_DEVICETREE = " \
     imx6q-pico-nymph.dtb \
     imx6q-pico-pi.dtb \
 "
-MACHINE_FEATURES += "bluetooth wifi"
-
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
     kernel-image \
     kernel-devicetree \


### PR DESCRIPTION
Remove the duplicate MACHINE_FEATURES entry.

There is a more complete one a few lines below.

Signed-off-by: Fabio Estevam <festevam@gmail.com>