### PR TITLE
Backport: Fix serial port, add QCA9377 Wifi support to imx6qdl-pico [to gatesgarth]

### DIFF
--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -12,7 +12,7 @@ require conf/machine/include/tune-cortexa9.inc
 IMX_DEFAULT_BSP = "mainline"
 IMX_DEFAULT_BOOTLOADER = "u-boot-fslc"
 
-SERIAL_CONSOLES = "115200;ttymxc4"
+SERIAL_CONSOLES = "115200;ttymxc0"
 
 SPL_BINARY = "SPL"
 UBOOT_SUFFIX = "img"

--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -35,6 +35,7 @@ KERNEL_DEVICETREE = " \
     imx6q-pico-nymph.dtb \
     imx6q-pico-pi.dtb \
 "
+MACHINE_FEATURES += "bluetooth wifi"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
     kernel-image \
@@ -49,3 +50,7 @@ MACHINE_EXTRA_RRECOMMENDS += " \
 WKS_FILES ?= "imx-uboot-spl.wks.in"
 WKS_FILE_DEPENDS ?= ""
 IMAGE_FSTYPES = "wic.bmap wic.xz ext4.gz"
+
+MACHINE_FIRMWARE_append = " linux-firmware-ath10k"
+
+MACHINE_FEATURES += " pci bluetooth touchscreen wifi"

--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -35,8 +35,6 @@ KERNEL_DEVICETREE = " \
     imx6q-pico-nymph.dtb \
     imx6q-pico-pi.dtb \
 "
-MACHINE_FEATURES += "bluetooth wifi"
-
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
     kernel-image \
     kernel-devicetree \


### PR DESCRIPTION
The following commits were cherry-picked from master:
imx6qdl-pico: Fix the serial console port (e253f15)
imx6qdl-pico: Add QCA9377 Wifi support (5f6c423)
imx6qdl-pico: Remove duplicate MACHINE_FEATURES entry (35acd10)