### PR TITLE
Update U-Boot 2020.07 and Linux Kernel 4.4.274 Fixing Vybrid

### DIFF
--- a/recipes-bsp/u-boot/u-boot-toradex-common.inc
+++ b/recipes-bsp/u-boot/u-boot-toradex-common.inc
@@ -10,7 +10,7 @@ DEPENDS += "flex-native bison-native"
 
 SRC_URI = "git://git.toradex.com/u-boot-toradex.git;branch=${SRCBRANCH}"
 
-SRCREV = "51b7d2f591d32916a3addab0193d07bbacb34aad"
+SRCREV = "7c9c42e93b9fda8c0bc27d5b8c81c4c289921c4b"
 SRCBRANCH = "toradex_2020.07"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/linux/linux-toradex_4.4.bb
+++ b/recipes-kernel/linux/linux-toradex_4.4.bb
@@ -8,13 +8,13 @@ SRC_URI = "git://git.toradex.com/linux-toradex.git;protocol=git;branch=${SRCBRAN
 
 KERNEL_MODULE_AUTOLOAD += "${@bb.utils.contains('COMBINED_FEATURES', 'usbgadget', ' libcomposite', '',d)}"
 
-LOCALVERSION = "-2.8.3"
+LOCALVERSION = "-0.0.0"
 PV_append = "+git${SRCPV}"
 
-LINUX_VERSION = "4.4.217"
+LINUX_VERSION = "4.4.274"
 
 SRCBRANCH = "toradex_vf_4.4"
-SRCREV = "4a31b8a3519d5dde0eacbb088b0d45c83732535b"
+SRCREV = "d900385139e5aa8d584dee92c87bb85d0226253e"
 
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(vf)"


### PR DESCRIPTION
Update U-Boot 2020.07 to latest and Linux kernel to 4.4.274 which fixes some issues a customer reported in trying to build for Colibri VF50/VF61. Thanks!