### PR TITLE
ffmpeg: append config flags for imx23

### DIFF
--- a/recipes-core/ffmpeg/ffmpeg_%.bbappend
+++ b/recipes-core/ffmpeg/ffmpeg_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF_append_mx23 = " --extra-libs=-latomic"


### PR DESCRIPTION
In order to build for armv5 we need to add -latomic to the build
configuration, otherwise:

	| arm-oe-linux-gnueabi-gcc  -march=armv5te -marm --sysroot=olinuxino/build/tmp-glibc/work/armv5e-oe-linux-gnueabi/ffmpeg/4.4-r0/recipe-sysroot -Llibavcodec -Llibavdevice -Llibavfilter -Llibavformat -Llibavresample -Llibavutil -Llibpostproc -Llibswscale -Llibswresample -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed  --sysroot=olinuxino/build/tmp-glibc/work/armv5e-oe-linux-gnueabi/ffmpeg/4.4-r0/recipe-sysroot -march=armv5te -Wl,--as-needed -Wl,-z,noexecstack -Wl,--warn-common -Wl,-rpath-link=:libpostproc:libswresample:libswscale:libavfilter:libavdevice:libavformat:libavcodec:libavutil:libavresample   -o ffprobe_g fftools/cmdutils.o fftools/ffprobe.o  -lavdevice -lavfilter -lavformat -lavcodec -lavresample -lswresample -lswscale -lavutil  -lm -lxcb -lxcb-shm -lxcb-shape -lxcb-xfixes -lasound -lXv -lX11 -lXext -pthread -lm -lm -lbz2 -lz -pthread -lm -llzma -lz -ltheoraenc -ltheoradec -logg -lm -lm -lm -pthread -lm -lXv -lX11 -lXext
	| olinuxino/build/tmp-glibc/work/armv5e-oe-linux-gnueabi/ffmpeg/4.4-r0/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/11.1.1/ld: libavformat/libavformat.so: undefined reference to `__atomic_fetch_sub_8'
	| olinuxino/build/tmp-glibc/work/armv5e-oe-linux-gnueabi/ffmpeg/4.4-r0/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/11.1.1/ld: libavformat/libavformat.so: undefined reference to `__atomic_store_8'
	| olinuxino/build/tmp-glibc/work/armv5e-oe-linux-gnueabi/ffmpeg/4.4-r0/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/11.1.1/ld: libavformat/libavformat.so: undefined reference to `__atomic_load_8'
	| olinuxino/build/tmp-glibc/work/armv5e-oe-linux-gnueabi/ffmpeg/4.4-r0/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/11.1.1/ld: libavformat/libavformat.so: undefined reference to `__atomic_fetch_add_8'

Signed-off-by: Trevor Woerner <twoerner@gmail.com>