### PR TITLE
hardknott: nitrogen8mp: define variables needed for imx-boot recipe (backport)

### DIFF
--- a/conf/machine/nitrogen8mp.conf
+++ b/conf/machine/nitrogen8mp.conf
@@ -38,8 +38,9 @@ UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "${BOUNDARY_DEVICES_UBOOT_DEFCONFIG}_defconfig,sdcard"
 
 IMAGE_BOOTLOADER = "imx-boot"
-
+ATF_PLATFORM = "imx8mp"
 IMXBOOT_TARGETS = "flash_evk"
+IMX_BOOT_SOC_TARGET = "iMX8MP"
 
 DDR_FIRMWARE_NAME = "\
     lpddr4_pmu_train_1d_imem_201904.bin \


### PR DESCRIPTION
Otherwise imx-boot will not compile.