### PR TITLE
lx2160acex7: Force to use version 5.4 when using linux-qoriq kernel

### DIFF
--- a/conf/machine/lx2160acex7.conf
+++ b/conf/machine/lx2160acex7.conf
@@ -40,6 +40,7 @@ USE_VT = "0"
 
 PREFERRED_PROVIDER_u-boot-default-script = "u-boot-script-qoriq"
 PREFERRED_PROVIDER_virtual/kernel = "linux-fslc-qoriq"
+PREFERRED_VERSION_linux-qoriq = "5.4%"
 PREFERRED_VERSION_u-boot-qoriq = "2019.10%"
 PREFERRED_VERSION_qoriq-atf = "1.5%"
 


### PR DESCRIPTION
Later versions are not compatible with this machine.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>