### PR TITLE
recipes: use https protocol and add explicit branch parameter

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf-boundary_2.3.bb
+++ b/recipes-bsp/imx-atf/imx-atf-boundary_2.3.bb
@@ -10,7 +10,7 @@ PROVIDES = "imx-atf"
 PV .= "+git${SRCPV}"
 
 SRCBRANCH = "boundary-imx_5.4.70_2.3.0"
-SRC_URI = "git://github.com/boundarydevices/imx-atf.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/boundarydevices/imx-atf.git;branch=${SRCBRANCH};protocol=https \
 "
 SRCREV = "9f6114fde03ebed6ecc482989a7660adc5a41a9d"
 

--- a/recipes-bsp/u-boot/u-boot-boundary-common_2020.10.inc
+++ b/recipes-bsp/u-boot/u-boot-boundary-common_2020.10.inc
@@ -6,7 +6,7 @@ PV = "v2020.10+git${SRCPV}"
 
 SRCREV = "6ed3b4647b1ca8d3cb33595c33e1c92b1fefb561"
 SRCBRANCH = "boundary-v2020.10"
-SRC_URI = "git://github.com/boundarydevices/u-boot-imx6.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/boundarydevices/u-boot-imx6.git;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-gateworks-imx_2015.04.bb
+++ b/recipes-bsp/u-boot/u-boot-gateworks-imx_2015.04.bb
@@ -8,7 +8,7 @@ DEPENDS = "u-boot-mkimage-native"
 PV = "v2015.04+git${SRCPV}"
 
 SRCREV = "040377aefd06c8eef41763868fc9c6df2cbf9b1c"
-SRC_URI = "git://github.com/Gateworks/u-boot-imx6.git;branch=gateworks_v2015.04"
+SRC_URI = "git://github.com/Gateworks/u-boot-imx6.git;branch=gateworks_v2015.04;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/u-boot/u-boot-remarkable2_2018.03.bb
+++ b/recipes-bsp/u-boot/u-boot-remarkable2_2018.03.bb
@@ -8,7 +8,7 @@ PV = "2018.03+git${SRCPV}"
 
 SRCREV = "47c91918aa7724c16b6eaf87cf5dfbf4548eafc1"
 SRCBRANCH = "zero-sugar"
-SRC_URI = "git://github.com/reMarkable/uboot.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/reMarkable/uboot.git;branch=${SRCBRANCH};protocol=https \
            file://0001-Remove-redundant-YYLOC-global-declaration.patch \
            file://0002-dtc-lexer.lex.c_shipped-Remove-redundant-YYLOC-globa.patch \
            file://0003-reMarkable-Print-output-to-pogo-pins.patch \

--- a/recipes-bsp/u-boot/u-boot-timesys_2011.12.bb
+++ b/recipes-bsp/u-boot/u-boot-timesys_2011.12.bb
@@ -10,7 +10,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1707d6db1d42237583f50183a5651ecb"
 
 SRCBRANCH = "2011.12-pcl052"
-SRC_URI = "git://github.com/Timesys/u-boot-timesys.git;protocol=git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/Timesys/u-boot-timesys.git;protocol=https;branch=${SRCBRANCH}"
 SRCREV = "dca5026484c69628be9b9618e5795c635cefe110"
 
 SRCBRANCH_quartz = "2011.12-quartz"

--- a/recipes-bsp/u-boot/u-boot-variscite_2018.03.bb
+++ b/recipes-bsp/u-boot/u-boot-variscite_2018.03.bb
@@ -16,7 +16,7 @@ SRCREV = "717f29898abe82ffa2d74515806c46094075285a"
 SRCBRANCH = "imx_v2018.03_4.14.78_1.0.0_ga_var02"
 
 SRC_URI = "\
-    git://github.com/varigit/uboot-imx.git;protocol=git;branch=${SRCBRANCH} \
+    git://github.com/varigit/uboot-imx.git;protocol=https;branch=${SRCBRANCH} \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-connectivity/ti-18xx-wlconf/ti-18xx-wlconf_8.7.3..bb
+++ b/recipes-connectivity/ti-18xx-wlconf/ti-18xx-wlconf_8.7.3..bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://README;beginline=1;endline=21;md5=adc05a1903d3f107f85
 
 # Tag: R8.7_SP3 (8.7.3)
 SRCREV = "5048b59a444ac59ba7171d6e122d5a84581aebf2"
-SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git"
+SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git;branch=master"
 
 S = "${WORKDIR}/git/wlconf"
 

--- a/recipes-kernel/kernel-module-mcc-toradex/kernel-module-mcc-toradex_1.06+toradex2.bb
+++ b/recipes-kernel/kernel-module-mcc-toradex/kernel-module-mcc-toradex_1.06+toradex2.bb
@@ -10,7 +10,7 @@ RPROVIDES:${PN}-dev = "virtual/kernel-module-mcc-dev"
 
 inherit module
 
-SRC_URI = "git://github.com/toradex/mcc-kmod.git;protocol=git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/toradex/mcc-kmod.git;protocol=https;branch=${SRCBRANCH}"
 
 SRCBRANCH = "master"
 SRCREV = "083388fa5cce79c239988d61543322d91996aa8d"

--- a/recipes-kernel/linux/linux-boundary_5.10.bb
+++ b/recipes-kernel/linux/linux-boundary_5.10.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 LINUX_VERSION = "5.10.63"
 
-SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH};protocol=https \
 "
 
 LOCALVERSION = "-2.0.0+yocto"

--- a/recipes-kernel/linux/linux-gateworks-imx_3.14.bb
+++ b/recipes-kernel/linux/linux-gateworks-imx_3.14.bb
@@ -7,7 +7,7 @@ DEPENDS += "lzop-native bc-native"
 
 SRCREV = "d9991ca465921e5ed120dd321e06a2d64eaa5099"
 LOCALVERSION = "-1.0.x-ga+yocto"
-SRC_URI = "git://github.com/Gateworks/linux-imx6.git;protocol=git;branch=gateworks_fslc_3.14_1.0.x_ga \
+SRC_URI = "git://github.com/Gateworks/linux-imx6.git;protocol=https;branch=gateworks_fslc_3.14_1.0.x_ga \
            file://defconfig"
 
 LINUX_VERSION = "3.14"

--- a/recipes-kernel/linux/linux-remarkable2_5.4.bb
+++ b/recipes-kernel/linux/linux-remarkable2_5.4.bb
@@ -3,7 +3,7 @@ require recipes-kernel/linux/linux-imx.inc
 SUMMARY = "Linux kernel for the reMarkable2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-SRC_URI = "git://github.com/alistair23/linux.git;protocol=git;branch=${KBRANCH}"
+SRC_URI = "git://github.com/alistair23/linux.git;protocol=https;branch=${KBRANCH}"
 KBRANCH = "5.4-rM2-2.2.x-imx"
 SRCREV = "d8cb1f6be94cd94fd72c3d5637143f7042dd8147"
 

--- a/recipes-kernel/linux/linux-variscite_4.14.bb
+++ b/recipes-kernel/linux/linux-variscite_4.14.bb
@@ -10,7 +10,7 @@ LINUX_VERSION = "4.14.78"
 SRCBRANCH = "imx_4.14.78_1.0.0_ga_var01"
 SRCREV = "0b8118cd4d7b802748ff1a5de17a31a2990cdefd"
 SRC_URI = "\
-    git://github.com/varigit/linux-imx.git;protocol=git;branch=${SRCBRANCH} \
+    git://github.com/varigit/linux-imx.git;protocol=https;branch=${SRCBRANCH} \
     file://defconfig \
 "
 


### PR DESCRIPTION
Due to https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
it is required to use https protocol for github repo accessing.

Update created with oe-core/scripts/contrib/convert-srcuri.py (see [0])

[0] - https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>