### PR TITLE
linux-boundary: bump revision to acef1311

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.10.bb
+++ b/recipes-kernel/linux/linux-boundary_5.10.bb
@@ -8,14 +8,14 @@ SUMMARY = "Linux kernel for Boundary Devices boards"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION = "5.10.63"
+LINUX_VERSION = "5.10.72"
 
 SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH} \
 "
 
 LOCALVERSION = "-2.0.0+yocto"
 SRCBRANCH = "boundary-imx_5.10.x_2.0.0"
-SRCREV = "06cdda6dc94e1da9217649221b8e91bc01546778"
+SRCREV = "acef1311bdaed94134de8894d733e5307abf8cb4"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
Changelog:
- update to 5.10.72
- more displays supported for i.MX8MP

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>
(cherry picked from commit 748b8f0e0754d30cb7f7c9098c9350b16b6569a7)