### PR TITLE
colibri-imx6ull: fix mistyped override

### DIFF
--- a/conf/machine/colibri-imx6ull.conf
+++ b/conf/machine/colibri-imx6ull.conf
@@ -14,7 +14,7 @@ KBUILD_DEFCONFIG:use-nxp-bsp ?= "colibri-imx6ull_defconfig"
 KERNEL_DEVICETREE += " \
     imx6ull-colibri-eval-v3.dtb imx6ull-colibri-wifi-eval-v3.dtb \
 "
-KERNEL_DEVICETREE:append:use_nxp_bsp = " \
+KERNEL_DEVICETREE:append:use-nxp-bsp = " \
     imx6ull-colibri-aster.dtb imx6ull-colibri-wifi-aster.dtb \
     imx6ull-colibri-iris.dtb imx6ull-colibri-wifi-iris.dtb \
     imx6ull-colibri-iris-v2.dtb imx6ull-colibri-wifi-iris-v2.dtb \


### PR DESCRIPTION
Fix mistype in colibri-imx6ull machine include file when using nxp bsp.

Reported-by: Tomas Vilda
Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>