### PR TITLE
imx7d-remarkable2: Remove bcm4345* firmwares as it has no providers

### DIFF
--- a/conf/machine/imx7d-remarkable2.conf
+++ b/conf/machine/imx7d-remarkable2.conf
@@ -33,7 +33,6 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
 MACHINE_EXTRA_RRECOMMENDS += " \
   linux-firmware-imx-sdma-imx7d \
   linux-firmware-bcm43455 \
-  linux-firmware-bcm43456 \
   wpa-supplicant \
 "
 


### PR DESCRIPTION
This is a workaround to successfully finish the building.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>