### PR TITLE
layers: Bump to use kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "freescale-3rdparty"
 BBFILE_PATTERN_freescale-3rdparty := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-3rdparty = "4"
 
-LAYERSERIES_COMPAT_freescale-3rdparty = "honister"
+LAYERSERIES_COMPAT_freescale-3rdparty = "kirkstone"
 LAYERDEPENDS_freescale-3rdparty = "core freescale-layer"


### PR DESCRIPTION
its not going to be backward ABI compatible with honister due to variable renaming.

Signed-off-by: Khem Raj <raj.khem@gmail.com>