### PR TITLE
nitrogen8mp: Define nxp as default BSP

### DIFF
--- a/conf/machine/nitrogen8mp.conf
+++ b/conf/machine/nitrogen8mp.conf
@@ -6,6 +6,8 @@
 
 MACHINEOVERRIDES =. "mx8:mx8m:mx8mp:"
 
+IMX_DEFAULT_BSP ?= "nxp"
+
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 


### PR DESCRIPTION
This commit solves the lack of a provider for 'imx-boot' due to nitrogen8mp not present in COMPATIBLE_MACHINE.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>