### PR TITLE
Rework machine definitions to reduce duplication

### DIFF
--- a/conf/machine/apalis-imx6.conf
+++ b/conf/machine/apalis-imx6.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Toradex Apalis iMX6 SOM
 #@MAINTAINER: Max Krummenacher <max.krummenacher@toradex.com>
 
-MACHINEOVERRIDES =. "mx6:mx6q:"
+MACHINEOVERRIDES =. "mx6q:"
 
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa9.inc

--- a/conf/machine/colibri-imx6.conf
+++ b/conf/machine/colibri-imx6.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Toradex Colibri iMX6 SOM
 #@MAINTAINER: Max Krummenacher <max.krummenacher@toradex.com>
 
-MACHINEOVERRIDES =. "mx6:mx6dl:"
+MACHINEOVERRIDES =. "mx6dl:"
 
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa9.inc

--- a/conf/machine/colibri-imx6ull.conf
+++ b/conf/machine/colibri-imx6ull.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Toradex Colibri iMX6 ULL SOM
 #@MAINTAINER: Max Krummenacher <max.krummenacher@toradex.com>
 
-MACHINEOVERRIDES =. "mx6:mx6ul:mx6ull:"
+MACHINEOVERRIDES =. "mx6ull:"
 
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa7.inc

--- a/conf/machine/cubox-i.conf
+++ b/conf/machine/cubox-i.conf
@@ -10,7 +10,7 @@
 # all SoCs from all of these machines to let recipes include firmware
 # etc. for all of these SoCs.
 
-MACHINEOVERRIDES =. "mx6:mx6dl:mx6q:"
+MACHINEOVERRIDES =. "mx6q:mx6dl:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc

--- a/conf/machine/imx6dl-riotboard.conf
+++ b/conf/machine/imx6dl-riotboard.conf
@@ -7,7 +7,7 @@
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa9.inc
 
-MACHINEOVERRIDES =. "mx6:mx6dl:"
+MACHINEOVERRIDES =. "mx6dl:"
 
 UBOOT_MACHINE = "riotboard_defconfig"
 UBOOT_SUFFIX = "imx"

--- a/conf/machine/imx6qdl-pico.conf
+++ b/conf/machine/imx6qdl-pico.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for IMX6QDL-PICO board.
 #@MAINTAINER: Otavio Salvador otavio.salvador@ossystems.com.br
 
-MACHINEOVERRIDES =. "mx6:mx6dl:mx6q:"
+MACHINEOVERRIDES =. "mx6q:mx6dl:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc

--- a/conf/machine/imx6qdl-variscite-som.conf
+++ b/conf/machine/imx6qdl-variscite-som.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Variscite i.MX6Q/DL VAR-SOM-MX6
 #@MAINTAINER: Fabio Berton <fabio.berton@ossystems.com.br>
 
-MACHINEOVERRIDES =. "mx6:mx6q:mx6dl:"
+MACHINEOVERRIDES =. "mx6q:mx6dl:"
 
 DEFAULTTUNE ?= "cortexa9thf-neon"
 require conf/machine/include/imx-base.inc

--- a/conf/machine/imx6sl-warp.conf
+++ b/conf/machine/imx6sl-warp.conf
@@ -22,7 +22,7 @@
 #correct node that corresponds to the Warp board. Passing an incorrect
 #device number may overwrite the host PC file system, causing boot issues there.
 
-MACHINEOVERRIDES =. "mx6:mx6sl:"
+MACHINEOVERRIDES =. "mx6sl:"
 
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa9.inc

--- a/conf/machine/imx6ul-kontron.conf
+++ b/conf/machine/imx6ul-kontron.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Kontron N63XX/N64XX SoM based boards
 #@MAINTAINER: Frieder Schrempf <frieder.schrempf@kontron.de>
 
-MACHINEOVERRIDES =. "mx6:mx6ul:"
+MACHINEOVERRIDES =. "mx6ul:"
 
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa7.inc

--- a/conf/machine/imx6ul-pico.conf
+++ b/conf/machine/imx6ul-pico.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for IMX6UL-PICO board.
 #@MAINTAINER: Daiane Angolini <daiane.angolini@nxp.com>
 
-MACHINEOVERRIDES =. "mx6:mx6ul:"
+MACHINEOVERRIDES =. "mx6ul:"
 
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa7.inc

--- a/conf/machine/nitrogen6sx.conf
+++ b/conf/machine/nitrogen6sx.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen6SX
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx6:mx6sx:"
+MACHINEOVERRIDES =. "mx6sx:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/nitrogen6x-lite.conf
+++ b/conf/machine/nitrogen6x-lite.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen6X Lite
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx6:mx6dl:"
+MACHINEOVERRIDES =. "mx6dl:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/nitrogen6x.conf
+++ b/conf/machine/nitrogen6x.conf
@@ -29,7 +29,7 @@
 #
 #
 
-MACHINEOVERRIDES =. "mx6:mx6dl:mx6q:"
+MACHINEOVERRIDES =. "mx6q:mx6dl:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/nitrogen8m.conf
+++ b/conf/machine/nitrogen8m.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen8M
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx8:mx8m:mx8mq:"
+MACHINEOVERRIDES =. "mx8mq:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/nitrogen8mm.conf
+++ b/conf/machine/nitrogen8mm.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen8MM
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx8:mx8m:mx8mm:"
+MACHINEOVERRIDES =. "mx8mm:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/nitrogen8mn.conf
+++ b/conf/machine/nitrogen8mn.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen8M Nano
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx8:mx8m:mx8mn:"
+MACHINEOVERRIDES =. "mx8mn:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/nitrogen8mp.conf
+++ b/conf/machine/nitrogen8mp.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen8MP
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx8:mx8m:mx8mp:"
+MACHINEOVERRIDES =. "mx8mp:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/ventana.conf
+++ b/conf/machine/ventana.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Gateworks Ventana boards.
 #@MAINTAINER: Pushpal Sidhu <psidhu@gateworks.com>
 
-MACHINEOVERRIDES =. "mx6:mx6dl:mx6q:"
+MACHINEOVERRIDES =. "mx6q:mx6dl:"
 
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc

--- a/conf/machine/wandboard.conf
+++ b/conf/machine/wandboard.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for i.MX6 Wandboard QuadPlus/Quad/Dual/Solo
 #@MAINTAINER: Alfonso Tames <alfonso@tames.com>
 
-MACHINEOVERRIDES =. "mx6:mx6dl:mx6q:"
+MACHINEOVERRIDES =. "mx6q:mx6dl:"
 
 include conf/machine/include/imx-base.inc
 include conf/machine/include/arm/armv7a/tune-cortexa9.inc


### PR DESCRIPTION
We reworked the SoC overrides so we avoids duplication and redundancy;
machines affected are:

 - apalis-imx6
 - colibri-imx6
 - colibri-imx6ull
 - cubox-i
 - imx6dl-riotboard
 - imx6qdl-pico
 - imx6qdl-variscite-som
 - imx6sl-warp
 - imx6ul-kontron
 - imx6ul-pico
 - nitrogen6sx
 - nitrogen6x-lite
 - nitrogen6x
 - ventana
 - wandboard
 - nitrogen8m
 - nitrogen8mm
 - nitrogen8mn
 - nitrogen8mp

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
