### PR TITLE
machines: follow kernel deployment changes

### DIFF
--- a/conf/machine/apalis-imx6.conf
+++ b/conf/machine/apalis-imx6.conf
@@ -19,7 +19,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " imx6q-apalis-ixora-v1.2.dtb"
 
 KERNEL_IMAGETYPE = "zImage"
 # The kernel lives in a seperate FAT partition, don't deploy it in /boot/
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 IMX_DEFAULT_BOOTLOADER = "u-boot-toradex"
 PREFERRED_RPROVIDER_u-boot-default-script = "u-boot-script-toradex"

--- a/conf/machine/colibri-imx6.conf
+++ b/conf/machine/colibri-imx6.conf
@@ -17,7 +17,7 @@ KERNEL_DEVICETREE += "imx6dl-colibri-eval-v3.dtb imx6dl-colibri-cam-eval-v3.dtb 
 KERNEL_DEVICETREE:use-mainline-bsp = "imx6dl-colibri-eval-v3.dtb"
 KERNEL_IMAGETYPE = "zImage"
 # The kernel lives in a seperate FAT partition, don't deploy it in /boot/
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 IMX_DEFAULT_BOOTLOADER = "u-boot-toradex"
 PREFERRED_PROVIDER_u-boot-default-script = "u-boot-script-toradex"

--- a/conf/machine/colibri-imx6ull.conf
+++ b/conf/machine/colibri-imx6ull.conf
@@ -22,7 +22,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
 
 KERNEL_IMAGETYPE = "zImage"
 # The kernel lives in its own ubi volume.
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 IMX_DEFAULT_BOOTLOADER = "u-boot-toradex"
 PREFERRED_PROVIDER_u-boot-default-script ?= "u-boot-script-toradex"

--- a/conf/machine/colibri-imx7-emmc.conf
+++ b/conf/machine/colibri-imx7-emmc.conf
@@ -21,7 +21,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
 "
 
 # The kernel lives in a seperate FAT partition, don't deploy it in /boot/
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 IMX_DEFAULT_BOOTLOADER = "u-boot-toradex"
 PREFERRED_RPROVIDER_u-boot-default-script = "u-boot-script-toradex"

--- a/conf/machine/colibri-imx7-nand.conf
+++ b/conf/machine/colibri-imx7-nand.conf
@@ -25,7 +25,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
 
 # U-Boot of our newer release read the Kernel and device tree from static UBI
 # volumes, hence no need to deploy the kernel binary in the image itself
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 IMX_DEFAULT_BOOTLOADER = "u-boot-toradex"
 PREFERRED_PROVIDER_u-boot-default-script ?= "u-boot-script-toradex"

--- a/conf/machine/colibri-vf.conf
+++ b/conf/machine/colibri-vf.conf
@@ -25,7 +25,7 @@ KERNEL_DEVICETREE:append:use-nxp-bsp = " \
 
 # U-Boot of our newer release read the Kernel and device tree from static UBI volumes,
 # hence no need to deploy the kernel binary in the image itself
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 IMX_DEFAULT_BOOTLOADER = "u-boot-toradex"
 PREFERRED_PROVIDER_u-boot-default-script ?= "u-boot-script-toradex"

--- a/conf/machine/nitrogen8m.conf
+++ b/conf/machine/nitrogen8m.conf
@@ -21,7 +21,7 @@ KERNEL_DEVICETREE = "freescale/imx8mq-nitrogen8m.dtb \
 	freescale/imx8mq-nitrogen8m-edp.dtb \
 "
 KERNEL_IMAGETYPE = "Image"
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 # U-Boot configuration
 PREFERRED_PROVIDER_u-boot ??= "u-boot-boundary"

--- a/conf/machine/nitrogen8mm.conf
+++ b/conf/machine/nitrogen8mm.conf
@@ -25,7 +25,7 @@ KERNEL_DEVICETREE = "freescale/imx8mq-nitrogen8m.dtb \
 	freescale/imx8mm-nitrogen8mm_som-tc358743.dtb \
 "
 KERNEL_IMAGETYPE = "Image"
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 # U-Boot configuration
 PREFERRED_PROVIDER_u-boot ??= "u-boot-boundary"

--- a/conf/machine/nitrogen8mn.conf
+++ b/conf/machine/nitrogen8mn.conf
@@ -20,7 +20,7 @@ KERNEL_DEVICETREE = "freescale/imx8mn-nitrogen8mn.dtb \
 
 KERNEL_IMAGETYPE = "Image"
 KERNEL_DEFCONFIG = "boundary_defconfig"
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 # U-Boot configuration
 PREFERRED_PROVIDER_u-boot ??= "u-boot-boundary"

--- a/conf/machine/nitrogen8mp.conf
+++ b/conf/machine/nitrogen8mp.conf
@@ -19,7 +19,7 @@ KERNEL_DEVICETREE = "freescale/imx8mp-nitrogen8mp.dtb \
 		      freescale/imx8mp-nitrogen8mp-m4.dtb \
 "
 KERNEL_IMAGETYPE = "Image"
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 # U-Boot configuration
 PREFERRED_PROVIDER_u-boot ??= "u-boot-boundary"


### PR DESCRIPTION
With OE core commit [1c90b27d2c](https://github.com/openembedded/openembedded-core/commit/1c90b27d2c65cfb4f9debf0272820b6a95942f76) ("kernel: make kernel-base recommend kernel-image, not depend") the way the kernel is deployed into the rootfs silently changed, i.e. there is no build or run time error/warning that the kernel binary is deployed despite one did not want it. 

Note that commit 1c90b27d2c is already in the kirkstone branch.

@gibsson I run my sed script over all files in the layers. So the nitrogen machines would be updated by this commit too. Hope you approve, otherwise I will rewrite the commit.