### PR TITLE
linux-boundary: bump version to 5.4 2.3.0

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.4.bb
+++ b/recipes-kernel/linux/linux-boundary_5.4.bb
@@ -8,14 +8,14 @@ SUMMARY = "Linux kernel for Boundary Devices boards"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-LINUX_VERSION = "5.4.80"
+LINUX_VERSION = "5.4.110"
 
 SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH};protocol=https \
 "
 
-LOCALVERSION = "-2.2.0+yocto"
-SRCBRANCH = "boundary-imx_5.4.x_2.2.0"
-SRCREV = "521466cb0f2cf0e51ed4f509ee633143ab62bf46"
+LOCALVERSION = "-2.3.0+yocto"
+SRCBRANCH = "boundary-imx_5.4.x_2.3.0"
+SRCREV = "ff5a4cd9334ca8c060eaccc2750edcd0070b4e12"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn)"
 


### PR DESCRIPTION
Linux version 5.4.110. Latest and greatest 5.4 kernel (5.4 2.2.0 branch
was obsolete).