### PR TITLE
colibri-imx6: use soft assignment for u-boot-default-script provider

### DIFF
--- a/conf/machine/colibri-imx6.conf
+++ b/conf/machine/colibri-imx6.conf
@@ -20,7 +20,7 @@ KERNEL_IMAGETYPE = "zImage"
 RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
 IMX_DEFAULT_BOOTLOADER = "u-boot-toradex"
-PREFERRED_PROVIDER_u-boot-default-script = "u-boot-script-toradex"
+PREFERRED_PROVIDER_u-boot-default-script ?= "u-boot-script-toradex"
 
 UBOOT_SUFFIX = "img"
 SPL_BINARY = "SPL"


### PR DESCRIPTION
Some users might want to change u-boot-default-script preferred
provider, so let's use a soft assignment for that.

Signed-off-by: Sergio Prado <sergio.prado@toradex.com>