### PR TITLE
imx-atf-boundary: update do_deploy to fix binary path as per imx-boot

### DIFF
--- a/recipes-bsp/imx-atf/imx-atf-boundary_2.3.bb
+++ b/recipes-bsp/imx-atf/imx-atf-boundary_2.3.bb
@@ -46,9 +46,9 @@ do_compile() {
 do_install[noexec] = "1"
 
 do_deploy() {
-    install -Dm 0644 ${S}/build/${ATF_PLATFORM}/release/bl31.bin ${DEPLOYDIR}/${BOOT_TOOLS}/bl31-${ATF_PLATFORM}.bin
+    install -Dm 0644 ${S}/build/${ATF_PLATFORM}/release/bl31.bin ${DEPLOYDIR}/bl31-${ATF_PLATFORM}.bin
     if ${BUILD_OPTEE}; then
-       install -m 0644 ${S}/build-optee/${ATF_PLATFORM}/release/bl31.bin ${DEPLOYDIR}/${BOOT_TOOLS}/bl31-${ATF_PLATFORM}.bin-optee
+       install -m 0644 ${S}/build-optee/${ATF_PLATFORM}/release/bl31.bin ${DEPLOYDIR}/bl31-${ATF_PLATFORM}.bin-optee
     fi
 }
 addtask deploy after do_compile


### PR DESCRIPTION
imx-boot was updated to copy a binary from different path, so need to
fix.