### PR TITLE
u-boot-kontron: Bump u-boot revision to 1e797797

### DIFF
--- a/recipes-bsp/u-boot/u-boot-kontron_2020.01.bb
+++ b/recipes-bsp/u-boot/u-boot-kontron_2020.01.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 SRC_URI = "git://git.kontron-electronics.de/linux/u-boot.git;protocol=https;branch=${SRCBRANCH} \
            file://fw_env.config \
 "
-SRCREV = "3d58441adf3e633279db6c96acb33a7aef4fd6f9"
+SRCREV = "1e797797ee430992e8bb0acbba293c5c748f925c"
 SRCBRANCH = "v2020.01-ktn"
 LOCALVERSION = "-ktn"
 


### PR DESCRIPTION
This change includes the following commits:

    - 1e797797ee4 kontron_mx6ul: Read second mac address from fuses
    - e53e9c23ee3 imx: imx8mm: kontron: Use new LPDDR4 config parameters
    - 9ecc52dde47 imx: imx8mm: kontron: Remove 100mt DDR setpoint
    - 7629f16df68 imx: imx8mm: kontron: lpddr4_timing.c: Add spaces for proper alignment
    - 9aa5a039b36 clk: imx8mm: fix clk set parent
    - eb5a1eb17ce arm64: dts: imx8mm: correct assigned clocks for FEC
    - 4456d7f8a6a Fix previous commit and add missing status property for i2c2
    - a7626e58983 imx: imx8mm: kontron: Add support for PMIC PCA9450
    - 367b3fc5799 power: pmic: add SPL_DM_PMIC_PCA9450 symbol to Kconfig
    - 461e97938f0 pca9450a: fix i2c address
    - 240d3ec16a4 power: pmic_pca9450: fix PCA9450A I2C address
    - 8218729034b power: Add new PMIC PCA9450 driver
    - b302334d858 spl.c: Fix detection of deprecated Kontron i.MX8MM SoMs
    - bc9b2bd160d mx8mm/spl.c in function do_board_detect: scan on i2c bus 1 for address 0x5d (goodix touchcontroller)
    - 5aa7e28b6ea imx: imx8mm: kontron: Fix ft_board_setup() return value
    - c3749ce1f33 imx: imx8mm: kontron: Fix check_ram_available() in SPL
    - 1d787eac353 imx: imx8mm: kontron: Use maximum DDR size of 3G + 5G = 8G
    - cdd9c994c50 imx: imx8mm: kontron: Use common dram_init()
    - 315561a22cd imx8m: Fix DDR runtime size detection with two banks
    - aa9f397b931 imx8m: fix cache setup for dynamic sdram size
    - cad96b678ab imx8m: Refactor the OPTEE memory removal
    - 2e4cdb1721b imx: imx8mm: kontron: Use local-mac-address dt property
    - e20a08238a8 imx: imx8mm: kontron: Drop support for old 2GB DDR and add support for 4GB DDR
    - 3ecce3a8f1f kontron_mx6ul: Fix accidental changes in previous commit
    - 90c0d7edf74 kontron_mx6ul: Fix ethernet support
    - 99df4d34743 driver: ddr: imx: correct the pwrctl setting of selfref_en on imx8m
    - 251849929f0 drivers: ddr: imx Workaround for i.MX8M DDRPHY rank to rank issue
    - 71934c0ef4a imx: imx8mm: kontron: Add support for 2GB Micron LPDDR4 RAM
    - 5066e4e1f59 imx: imx6ul: kontron: Change SPL board type message
    - 41a68de2b2d imx: imx8mm: kontron: Update and simplify SoM and board configurations
    - d536f5630c4 arm: dts: imx8mm: sync dts from Linux Kernel 5.6.7
    - 3ed9c8db468 imx: imx8mm: kontron: Fix SPL boot device order
    - 6e3ff8cff5d mtd: spinand: toshiba: Support for new Kioxia Serial NAND
    - 803f8cc35bd mtd: spinand: toshiba: Rename function name to change suffix and prefix (8Gbit)
    - 7deb52833cb mtd: nand: spi: add support for Toshiba TC58CVG2S0HRAIJ
    - 34f8f069bfa kontron_mx6ul: Use the SPI NOR as a fallback boot device to load U-Boot proper
    - 50056aa5063 Revert "kontron_mx6ul: Use the SPI NOR as primary boot device to load U-Boot proper"

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>