### PR TITLE
linux-boundary: bump revision to 45abf648

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.15.bb
+++ b/recipes-kernel/linux/linux-boundary_5.15.bb
@@ -8,14 +8,14 @@ SUMMARY = "Linux kernel for Boundary Devices boards"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION = "5.15.38"
+LINUX_VERSION = "5.15.52"
 
 SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH};protocol=https \
 "
 
-LOCALVERSION = "-1.0.0+yocto"
+LOCALVERSION = "-2.1.0+yocto"
 SRCBRANCH = "boundary-imx_5.15.y"
-SRCREV = "eb43cb07016f40414dfcdf5b36262ea87e0bb1ef"
+SRCREV = "45abf648ed0ead8c2dbace3d849e0a1d06282dba"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
Linux Version 5.15.52.

Signed-off-by: Chris Dimich <chris.dimich@boundarydevices.com>