### PR TITLE
nitrogen8m...: remove obsolete imx-boot-container override

### DIFF
--- a/conf/machine/nitrogen8m.conf
+++ b/conf/machine/nitrogen8m.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen8M
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx8mq:imx-boot-container:"
+MACHINEOVERRIDES =. "mx8mq:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/nitrogen8mm.conf
+++ b/conf/machine/nitrogen8mm.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen8MM
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx8mm:imx-boot-container:"
+MACHINEOVERRIDES =. "mx8mm:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/nitrogen8mn.conf
+++ b/conf/machine/nitrogen8mn.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen8M Nano
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx8mn:imx-boot-container:"
+MACHINEOVERRIDES =. "mx8mn:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 

--- a/conf/machine/nitrogen8mp.conf
+++ b/conf/machine/nitrogen8mp.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for Boundary Devices Nitrogen8MP
 #@MAINTAINER: Chris Dimich <chris.dimich@boundarydevices.com>
 
-MACHINEOVERRIDES =. "mx8mp:imx-boot-container:"
+MACHINEOVERRIDES =. "mx8mp:"
 
 IMX_DEFAULT_BSP ?= "nxp"
 


### PR DESCRIPTION
@chrisdimich 

This would cleanup the machine if https://github.com/Freescale/meta-freescale/pull/1488 should goes in

With that pull request the imx-boot-container override would no longer be used anywhere. imx-boot would be provided for all i.MX 8Mx machines by U-Boot, (for i.MX8X and i.MX8QM it stays with the imx-boot recipe).