### PR TITLE
boundary: update kernel + cleanup

### DIFF
--- a/conf/machine/nitrogen8mm.conf
+++ b/conf/machine/nitrogen8mm.conf
@@ -13,9 +13,7 @@ require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 
 # Kernel configuration
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-boundary"
-KERNEL_DEVICETREE = "freescale/imx8mq-nitrogen8m.dtb \
-	freescale/imx8mq-nitrogen8m-m4.dtb \
-        freescale/imx8mm-nitrogen8mm.dtb \
+KERNEL_DEVICETREE = "freescale/imx8mm-nitrogen8mm.dtb \
 	freescale/imx8mm-nitrogen8mm_som.dtb \
 	freescale/imx8mm-nitrogen8mm_rev2.dtb \
 	freescale/imx8mm-nitrogen8mm_rev2-m4.dtb \

--- a/conf/machine/nitrogen8mn.conf
+++ b/conf/machine/nitrogen8mn.conf
@@ -14,8 +14,10 @@ require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 # Kernel configuration
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-boundary"
 KERNEL_DEVICETREE = "freescale/imx8mn-nitrogen8mn.dtb \
-		     freescale/imx8mn-nitrogen8mn_som.dtb \
-		     freescale/imx8mn-nitrogen8_nano.dtb \
+	freescale/imx8mn-nitrogen8mn_som.dtb \
+	freescale/imx8mn-nitrogen8mn_som-m4.dtb \
+	freescale/imx8mn-nitrogen8_nano.dtb \
+	freescale/imx8mn-nitrogen8_nano-m4.dtb \
 "
 
 KERNEL_IMAGETYPE = "Image"

--- a/conf/machine/nitrogen8mp.conf
+++ b/conf/machine/nitrogen8mp.conf
@@ -14,9 +14,10 @@ require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 # Kernel configuration
 PREFERRED_PROVIDER_virtual/kernel ??= "linux-boundary"
 KERNEL_DEVICETREE = "freescale/imx8mp-nitrogen8mp.dtb \
-		      freescale/imx8mp-nitrogen8mp-enc.dtb \
-		      freescale/imx8mp-nitrogen8mp-enc-tc358743.dtb \
-		      freescale/imx8mp-nitrogen8mp-m4.dtb \
+	freescale/imx8mp-nitrogen8mp-enc.dtb \
+	freescale/imx8mp-nitrogen8mp-enc-m4.dtb \
+	freescale/imx8mp-nitrogen8mp-enc-tc358743.dtb \
+	freescale/imx8mp-nitrogen8mp-m4.dtb \
 "
 KERNEL_IMAGETYPE = "Image"
 RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""

--- a/recipes-kernel/linux/linux-boundary_5.15.bb
+++ b/recipes-kernel/linux/linux-boundary_5.15.bb
@@ -10,12 +10,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 LINUX_VERSION = "5.15.71"
 
-SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH};protocol=https \
+SRC_URI = "git://github.com/boundarydevices/linux.git;branch=${SRCBRANCH};protocol=https \
 "
 
 LOCALVERSION = "-2.2.0+yocto"
 SRCBRANCH = "boundary-imx_5.15.y"
-SRCREV = "b2f34070b1ec1f4182165507e5259b591ff0fd8f"
+SRCREV = "8666151fcb5bcadde997e4f7fb35e4414b14817e"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
This series cleans up the configurations to include all the necessary dtb and remove the one not matching the architecture.
It also updates the kernel to the latest version.
Would need to be back-ported to kirkstone.