### PR TITLE
linux-boundary: bump revision to d4a57b30

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.15.bb
+++ b/recipes-kernel/linux/linux-boundary_5.15.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/boundarydevices/linux.git;branch=${SRCBRANCH};protoc
 
 LOCALVERSION = "-2.2.0+yocto"
 SRCBRANCH = "boundary-imx_5.15.y"
-SRCREV = "7311f82acd8285b98e6f98d2f368993c15ad6b7e"
+SRCREV = "d4a57b30c1d1f018acd340cff4aecba3d64a950e"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
To support Cypress based Wifi and BT modules such as the LWB5+.