### PR TITLE
conf/layer.conf: add back compatibility to kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "freescale-3rdparty"
 BBFILE_PATTERN_freescale-3rdparty := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-3rdparty = "4"
 
-LAYERSERIES_COMPAT_freescale-3rdparty = "langdale mickledore"
+LAYERSERIES_COMPAT_freescale-3rdparty = "kirkstone langdale mickledore"
 LAYERDEPENDS_freescale-3rdparty = "core freescale-layer"


### PR DESCRIPTION
Main meta-freescale layer is compatible and can also be used with OE kirkstone, so follow the same change as this layer is mostly an extra to the main layer.