### PR TITLE
linux-boundary: fix LOCALVERSION

### DIFF
--- a/recipes-kernel/linux/linux-boundary_6.1.bb
+++ b/recipes-kernel/linux/linux-boundary_6.1.bb
@@ -13,7 +13,7 @@ LINUX_VERSION = "6.1.22"
 SRC_URI = "git://github.com/boundarydevices/linux.git;branch=${SRCBRANCH};protocol=https \
 "
 
-LOCALVERSION = "-1.22+yocto"
+LOCALVERSION = "+yocto"
 SRCBRANCH = "boundary-imx_6.1.y"
 SRCREV = "46a61156410f484008086b36c03ab8490a38731a"
 DEPENDS += "lzop-native bc-native"


### PR DESCRIPTION
Will print as:

6.1.22+yocto+g46a61156410f