### PR TITLE
gatesgarth: linux-boundary: bump revision to 416a208

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.4.bb
+++ b/recipes-kernel/linux/linux-boundary_5.4.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH} \
 
 LOCALVERSION = "-2.3.0+yocto"
 SRCBRANCH = "boundary-imx_5.4.x_2.3.0"
-SRCREV = "e5cde7b05e548bebb7cc21113505538b98c0984e"
+SRCREV = "416a2089741b864c5073dc2e0090229f6bcbc8df"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
Mainly to support Micrel PHY.