### PR TITLE
Master: linux-boundary: bump revision to ba56160e

### DIFF
--- a/recipes-kernel/linux/linux-boundary_6.1.bb
+++ b/recipes-kernel/linux/linux-boundary_6.1.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/boundarydevices/linux.git;branch=${SRCBRANCH};protoc
 
 LOCALVERSION = "+yocto"
 SRCBRANCH = "boundary-imx_6.1.y"
-SRCREV = "46a61156410f484008086b36c03ab8490a38731a"
+SRCREV = "ba56160ecafbdd386f6a60d7339f15821186b6a6"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
For 8mp Smarc rev1 fixes.