### PR TITLE
Kirkstone: linux-boundary: bump revision to 0d2e8ff2

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.15.bb
+++ b/recipes-kernel/linux/linux-boundary_5.15.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/boundarydevices/linux.git;branch=${SRCBRANCH};protoc
 
 LOCALVERSION = "-2.2.0+yocto"
 SRCBRANCH = "boundary-imx_5.15.y"
-SRCREV = "0adfddbb2f41258ce7b0f4650e109a4049b286ee"
+SRCREV = "0d2e8ff2b3a96a3be9f2243d78f9953afa0569cf"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
For 8mp Smarc rev1 fixes.