### PR TITLE
ARM 32-bit device-tree reorganization

### DIFF
--- a/conf/machine/include/imx233-olinuxino.inc
+++ b/conf/machine/include/imx233-olinuxino.inc
@@ -17,6 +17,6 @@ IMXBOOTLETS_MACHINE = "stmp378x_dev"
 UBOOT_MACHINE = "mx23_olinuxino_config"
 
 KERNEL_IMAGETYPE = "uImage"
-KERNEL_DEVICETREE = "imx23-olinuxino.dtb"
+KERNEL_DEVICETREE = "nxp/mxs/imx23-olinuxino.dtb"
 
 MACHINE_FEATURES = "usbgadget usbhost vfat"

--- a/conf/machine/wandboard.conf
+++ b/conf/machine/wandboard.conf
@@ -24,13 +24,13 @@ WANDBOARD_DEFAULT_KERNEL = "linux-wandboard"
 WANDBOARD_DEFAULT_KERNEL:use-mainline-bsp = "linux-fslc"
 PREFERRED_PROVIDER_virtual/kernel ?= "${WANDBOARD_DEFAULT_KERNEL}"
 KERNEL_DEVICETREE = " \
-    imx6dl-wandboard.dtb \
-    imx6dl-wandboard-revb1.dtb \
-    imx6dl-wandboard-revd1.dtb \
-    imx6q-wandboard.dtb \
-    imx6q-wandboard-revb1.dtb \
-    imx6q-wandboard-revd1.dtb \
-    imx6qp-wandboard-revd1.dtb \
+    nxp/imx/imx6dl-wandboard.dtb \
+    nxp/imx/imx6dl-wandboard-revb1.dtb \
+    nxp/imx/imx6dl-wandboard-revd1.dtb \
+    nxp/imx/imx6q-wandboard.dtb \
+    nxp/imx/imx6q-wandboard-revb1.dtb \
+    nxp/imx/imx6q-wandboard-revd1.dtb \
+    nxp/imx/imx6qp-wandboard-revd1.dtb \
 "
 
 KERNEL_IMAGETYPE = "zImage"


### PR DESCRIPTION
The 32-bit ARM device trees in the Linux kernel were reorganized in a manner similar to how the 64-bit ARM device trees have always been organized: by placing them in vendor+family subdirectories. Therefore update the KERNEL_DEVICETREE definitions to match.