### PR TITLE
Master: linux-boundary: bump revision to 2ada7473

### DIFF
--- a/recipes-kernel/linux/linux-boundary_6.1.bb
+++ b/recipes-kernel/linux/linux-boundary_6.1.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/boundarydevices/linux.git;branch=${SRCBRANCH};protoc
 
 LOCALVERSION = "+yocto"
 SRCBRANCH = "boundary-imx_6.1.y"
-SRCREV = "f6aefb45c69b0a252a46179cadc7855d343f4a3c"
+SRCREV = "2ada74733c2724fed72b202212d3547d0fdb3531"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
Mainly for Nitrogen 8M Mini SMARC fixes.