### PR TITLE
linux-boundary: bump revision to 7a916058

### DIFF
--- a/recipes-kernel/linux/linux-boundary_6.1.bb
+++ b/recipes-kernel/linux/linux-boundary_6.1.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/boundarydevices/linux.git;branch=${SRCBRANCH};protoc
 
 LOCALVERSION = "+yocto"
 SRCBRANCH = "boundary-imx_6.1.y"
-SRCREV = "376fc5832ae8928d1e38086b180af2ffa266bd58"
+SRCREV = "7a916058577483224ac0593e4bebfca01315c6a9"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
Mainly for nitrogen93 and nitrogen8ulp fixes.