### PR TITLE
layer.conf: Update to styhead

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "freescale-3rdparty"
 BBFILE_PATTERN_freescale-3rdparty := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-3rdparty = "4"
 
-LAYERSERIES_COMPAT_freescale-3rdparty = "kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_freescale-3rdparty = "styhead"
 LAYERDEPENDS_freescale-3rdparty = "core freescale-layer"


### PR DESCRIPTION
Drop all older release names as there have been potentially incompatible changes, e.g. the S must not point to WORKDIR.