### PR TITLE
honor vendor prefix in kernels >= 6.5

### DIFF
--- a/conf/machine/colibri-imx6.conf
+++ b/conf/machine/colibri-imx6.conf
@@ -11,10 +11,15 @@ include conf/machine/include/arm/armv7a/tune-cortexa9.inc
 
 PREFERRED_PROVIDER_virtual/kernel:use-nxp-bsp ??= "linux-toradex"
 KBUILD_DEFCONFIG:use-nxp-bsp ?= "colibri_imx6_defconfig"
-KERNEL_DEVICETREE += "imx6dl-colibri-eval-v3.dtb imx6dl-colibri-cam-eval-v3.dtb \
-                      imx6dl-colibri-aster.dtb imx6dl-colibri-iris.dtb \
-                      imx6dl-colibri-iris-v2.dtb"
-KERNEL_DEVICETREE:use-mainline-bsp = "imx6dl-colibri-eval-v3.dtb"
+KERNEL_DTB_PREFIX = "nxp/imx/"
+KERNEL_DEVICETREE += "\
+    ${KERNEL_DTB_PREFIX}imx6dl-colibri-eval-v3.dtb \
+    ${KERNEL_DTB_PREFIX}imx6dl-colibri-cam-eval-v3.dtb \
+    ${KERNEL_DTB_PREFIX}imx6dl-colibri-aster.dtb \
+    ${KERNEL_DTB_PREFIX}imx6dl-colibri-iris.dtb \
+    ${KERNEL_DTB_PREFIX}imx6dl-colibri-iris-v2.dtb \
+    "
+KERNEL_DEVICETREE:use-mainline-bsp = "${KERNEL_DTB_PREFIX}imx6dl-colibri-eval-v3.dtb"
 KERNEL_IMAGETYPE = "zImage"
 # The kernel lives in a seperate FAT partition, don't deploy it in /boot/
 RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""


### PR DESCRIPTION
I needed to add the nxp/imx prefix for the device tree in order to compile a 6.6 kernel 