### PR TITLE
Fix issues with the UNPACKDIR transition

### DIFF
--- a/recipes-bsp/broadcom-nvram-config/broadcom-nvram-config.inc
+++ b/recipes-bsp/broadcom-nvram-config/broadcom-nvram-config.inc
@@ -5,14 +5,14 @@ SRC_URI = " \
    file://LICENCE.broadcom_bcm43xx \
 "
 
-S = "${WORKDIR}"
+S = "${UNPACKDIR}"
 BRCM_FWDIR = "${nonarch_base_libdir}/firmware/brcm"
 CHIP_MODEL ?= "Invalid"
 
 do_install() {
     install -d  ${D}${BRCM_FWDIR}
 
-    cp -r ${WORKDIR}/brcmfmac${CHIP_MODEL}-sdio.txt \
+    cp -r ${UNPACKDIR}/brcmfmac${CHIP_MODEL}-sdio.txt \
         ${D}${BRCM_FWDIR}
 }
 

--- a/recipes-bsp/u-boot/u-boot-script-qoriq_2019.10.bb
+++ b/recipes-bsp/u-boot/u-boot-script-qoriq_2019.10.bb
@@ -26,7 +26,7 @@ do_compile() {
     kernel_devicetree="${kernel_devicetree_tmp}"
     sed -e 's/@KERNEL_BOOTCMD[@]/${KERNEL_BOOTCMD}/' -e "s,@KERNEL_IMAGETYPE[@],${KERNEL_IMAGETYPE},g" \
 	-e "s,@KERNEL_DEVICETREE[@],${kernel_devicetree},g" \
-        "${WORKDIR}/boot.cmd.in" > ${B}/boot.cmd
+        "${UNPACKDIR}/boot.cmd.in" > ${B}/boot.cmd
     target_arch="${TARGET_ARCH}"
     test "${TARGET_ARCH}" = "aarch64" && target_arch="arm64"
     mkimage -A ${target_arch} -T script -C none -n "Distro boot script" -d ${B}/boot.cmd ${B}/boot.scr

--- a/recipes-bsp/u-boot/u-boot-script-toradex_2020.07.bb
+++ b/recipes-bsp/u-boot/u-boot-script-toradex_2020.07.bb
@@ -20,7 +20,7 @@ do_compile[noexec] = "1"
 do_mkimage() {
     sed -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
-        "${WORKDIR}/boot.cmd.in" > ${B}/boot.cmd
+        "${UNPACKDIR}/boot.cmd.in" > ${B}/boot.cmd
     mkimage -T script -C none -n "Distro boot script" -d ${B}/boot.cmd ${B}/boot.scr
 }
 

--- a/recipes-core/net-persistent-mac/net-persistent-mac.bb
+++ b/recipes-core/net-persistent-mac/net-persistent-mac.bb
@@ -14,10 +14,10 @@ SRC_URI = "file://init \
 
 do_install () {
 	install -d ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/${PN}
+	install -m 0755 ${UNPACKDIR}/init ${D}${sysconfdir}/init.d/${PN}
 
 	install -d ${D}${sysconfdir}/default
-	install -m 0644 ${WORKDIR}/default ${D}${sysconfdir}/default/${PN}
+	install -m 0644 ${UNPACKDIR}/default ${D}${sysconfdir}/default/${PN}
 }
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -8,7 +8,7 @@ SRC_URI:append:imx6qdl-variscite-som = "\
 SRC_URI[TIInit_11.8.32.sha256sum] = "26ab0608e39fab95a6a55070c2f8364c92aad34442e8349abda71cee4da3277a"
 
 do_install:append:imx6qdl-variscite-som() {
-    cp ${WORKDIR}/TIInit_11.8.32.bts ${D}${nonarch_base_libdir}/firmware/ti-connectivity/
+    cp ${UNPACKDIR}/TIInit_11.8.32.bts ${D}${nonarch_base_libdir}/firmware/ti-connectivity/
 }
 
 PACKAGE_ARCH:imx6qdl-variscite-som = "${MACHINE_ARCH}"

--- a/recipes-kernel/linux/linux-fslc_%.bbappend
+++ b/recipes-kernel/linux/linux-fslc_%.bbappend
@@ -9,5 +9,5 @@ SRC_URI:append:imx6qdl-variscite-som:use-mainline-bsp = " \
 "
 
 do_configure:prepend:imx6qdl-variscite-som() {
-    cp ${WORKDIR}/imx6*-var*.dts* ${S}/arch/arm/boot/dts
+    cp ${UNPACKDIR}/imx6*-var*.dts* ${S}/arch/arm/boot/dts
 }


### PR DESCRIPTION
Update a few recipes to use UNPACKDIR instead of WORKDIR directly. This fixes building against newer master openembedded-core, at least for the wandboard machine.