### PR TITLE
linux-boundary: bump rev to 51c8fea5875f

### DIFF
--- a/recipes-kernel/linux/linux-boundary_5.15.bb
+++ b/recipes-kernel/linux/linux-boundary_5.15.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/boundarydevices/linux.git;branch=${SRCBRANCH};protoc
 
 LOCALVERSION = "-2.2.0+yocto"
 SRCBRANCH = "boundary-imx_5.15.y"
-SRCREV = "aaf028b285b7e5fcccd262a1fe61fbf16074f1f9"
+SRCREV = "51c8fea5875f876f279e255981ab9db092b275ea"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7|nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp)"
 


### PR DESCRIPTION
Changelog:
51c8fea5875f gpu: drm: panel: sn65dsi83: mask clock irq
bb32f223a52d arm64: dts: imx8mp-mmr: Initial device-tree
4a267a5e2661 arm: imx8mm-nitrogen_smarc: enable usb otg support
f528b26ca34a arm: dts: imx8mm-nitrogen_smarc: disable adma for SDIO wifi