### PR TITLE
recipes: fix whitespace warnings

### DIFF
--- a/recipes-bsp/atf/qoriq-atf_1.5.bb
+++ b/recipes-bsp/atf/qoriq-atf_1.5.bb
@@ -31,8 +31,8 @@ RCW_FOLDER ?= "${MACHINE}"
 RCW_FOLDER:ls1088ardb-pb = "ls1088ardb"
 
 # requires CROSS_COMPILE set by hand as there is no configure script
-export CROSS_COMPILE="${TARGET_PREFIX}"
-export ARCH="arm64"
+export CROSS_COMPILE = "${TARGET_PREFIX}"
+export ARCH = "arm64"
 
 # Let the Makefile handle setting up the CFLAGS and LDFLAGS as it is
 # a standalone application

--- a/recipes-bsp/u-boot/u-boot-qoriq_2019.10.bb
+++ b/recipes-bsp/u-boot/u-boot-qoriq_2019.10.bb
@@ -24,7 +24,7 @@ SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/u-boot;no
     file://0001-buildman-Convert-to-Python-3.patch \
     file://0001-Remove-redundant-YYLOC-global-declaration.patch \
 "
-SRCREV= "1e55b2f9e7f56b76569089b9e950f49c1579580e"
+SRCREV = "1e55b2f9e7f56b76569089b9e950f49c1579580e"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"


### PR DESCRIPTION
Since OE bitbake commit 24772dd2ae6c ("parse/ConfHandler: Add warning for deprecated whitespace usage"), the current build generates the following warning (as example):

| WARNING: .../meta-freescale-3rdparty/recipes-bsp/atf/qoriq-atf_1.5.bb:34 has a lack
| of whitespace around the assignment: 'export CROSS_COMPILE="${TARGET_PREFIX}"'

Fix all the warnings.